### PR TITLE
Update press-this.css

### DIFF
--- a/assets/press-this.css
+++ b/assets/press-this.css
@@ -2028,7 +2028,7 @@ html {
 
 .press-this .modal-close {
 	display: block;
-	width: 100%;
+	width: 90%;
 	padding: 13px 14px;
 	border: 0;
 	border-bottom: 1px solid #e5e5e5;


### PR DESCRIPTION
Due to the width of the class .press-this .modal-close, user was not able to create new categories.