### PR TITLE
Fix critical error saving posts with external images via REST

### DIFF
--- a/press-this-plugin.php
+++ b/press-this-plugin.php
@@ -343,6 +343,11 @@ function press_this_rest_save_post( $request ) {
 	}
 
 	// Side-load images from content.
+	// Require admin includes needed by media_sideload_image() (not loaded in REST context).
+	require_once ABSPATH . 'wp-admin/includes/file.php';
+	require_once ABSPATH . 'wp-admin/includes/media.php';
+	require_once ABSPATH . 'wp-admin/includes/image.php';
+
 	$wp_press_this = new WP_Press_This_Plugin();
 	press_this_http_request_context( true );
 	$post_data['post_content'] = $wp_press_this->side_load_images( $post_id, wp_slash( $post_data['post_content'] ) );

--- a/tests/php/test-integration.php
+++ b/tests/php/test-integration.php
@@ -204,4 +204,83 @@ class Test_Press_This_Integration extends BaseTestCase {
 
 		$this->assertArrayHasKey( 'redirInParent', $settings );
 	}
+
+	/**
+	 * Test 11: REST save handler includes admin files for image sideloading.
+	 *
+	 * Regression test for GitHub issue #74.
+	 *
+	 * The REST save handler calls side_load_images() which uses
+	 * media_sideload_image() from wp-admin/includes/media.php. In a
+	 * real REST API request, admin includes are NOT loaded by default,
+	 * so the function must explicitly require them. Without these
+	 * includes, saving a post with external images causes a PHP fatal
+	 * error: "Call to undefined function media_sideload_image()".
+	 *
+	 * Note: WorDBless preloads admin includes, so we cannot reproduce
+	 * the fatal error directly. Instead we verify the function source
+	 * contains the required require_once statements.
+	 *
+	 * @covers ::press_this_rest_save_post
+	 */
+	public function test_rest_save_requires_admin_media_includes() {
+		$func       = new ReflectionFunction( 'press_this_rest_save_post' );
+		$file_lines = file( $func->getFileName() );
+		$body       = implode( '', array_slice( $file_lines, $func->getStartLine() - 1, $func->getEndLine() - $func->getStartLine() + 1 ) );
+
+		$this->assertStringContainsString( "wp-admin/includes/file.php", $body, 'Missing require for file.php (provides download_url)' );
+		$this->assertStringContainsString( "wp-admin/includes/media.php", $body, 'Missing require for media.php (provides media_sideload_image)' );
+		$this->assertStringContainsString( "wp-admin/includes/image.php", $body, 'Missing require for image.php (provides wp_generate_attachment_metadata)' );
+	}
+
+	/**
+	 * Test 12: REST save with external images in content succeeds.
+	 *
+	 * Functional companion to test 11. Exercises the full save code path
+	 * with content containing an external image and a featured_image set,
+	 * matching the scenario from GitHub issue #74.
+	 *
+	 * @covers ::press_this_rest_save_post
+	 */
+	public function test_rest_save_with_external_images_succeeds() {
+		// Block HTTP requests to prevent actual image downloads.
+		$block_http = function () {
+			return new WP_Error( 'http_blocked', 'Blocked in test' );
+		};
+		add_filter( 'pre_http_request', $block_http, 1 );
+
+		// Create a draft post owned by the test user.
+		$post_id = wp_insert_post(
+			array(
+				'post_author'  => $this->editor_user_id,
+				'post_status'  => 'draft',
+				'post_title'   => 'Test Post',
+				'post_content' => '',
+			)
+		);
+
+		// Build a REST request whose content contains an external image.
+		$request = new WP_REST_Request( 'POST', '/press-this/v1/save' );
+		$request->set_param( 'post_id', $post_id );
+		$request->set_param( 'title', 'Test Save With Image' );
+		$request->set_param(
+			'content',
+			'<!-- wp:image -->'
+			. '<figure class="wp-block-image"><img src="https://example.com/photo.jpg" alt=""/></figure>'
+			. '<!-- /wp:image -->'
+		);
+		$request->set_param( 'featured_image', 1 );
+
+		$response = press_this_rest_save_post( $request );
+
+		$this->assertInstanceOf( WP_REST_Response::class, $response );
+		$data = $response->get_data();
+		$this->assertTrue( $data['success'] );
+
+		// Verify the post was actually updated.
+		$post = get_post( $post_id );
+		$this->assertEquals( 'Test Save With Image', $post->post_title );
+
+		remove_filter( 'pre_http_request', $block_http, 1 );
+	}
 }


### PR DESCRIPTION
## Summary
- Add missing `require_once` for `wp-admin/includes/file.php`, `media.php`, and `image.php` in the REST save endpoint
- Add regression test verifying the includes are present, plus a functional test exercising the full save-with-external-images path

## Root cause
The REST save handler calls `side_load_images()` which uses `media_sideload_image()`. REST API requests don't load `wp-admin/includes/` by default, causing a PHP fatal error when the content contains external `<img>` tags (e.g. scraped images inserted via the media panel).

Fixes #74

## Test plan
- [ ] Open Press This, scrape a page with images
- [ ] Insert a scraped image into the editor content
- [ ] Set a featured image from the sidebar panel
- [ ] Save as draft — should succeed without error
- [ ] Verify `phpunit` passes (75 tests, 223 assertions)