### PR TITLE
Register undo/redo keyboard shortcuts for block editor

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -311,15 +311,25 @@ export default function App() {
 	}, [] );
 
 	// State for undo/redo from editor.
-	const [ undoState, setUndoState ] = useState( {
-		handleUndo: null,
-		handleRedo: null,
-		hasUndo: false,
-		hasRedo: false,
-	} );
+	// Split into primitive values so React can skip re-renders when values
+	// haven't changed (Object.is comparison). The handlers are stable refs
+	// from useCallback, so setUndoHandler/setRedoHandler rarely trigger
+	// re-renders. The booleans only toggle on undo/redo stack transitions.
+	const [ undoHandler, setUndoHandler ] = useState( null );
+	const [ redoHandler, setRedoHandler ] = useState( null );
+	const [ hasUndo, setHasUndo ] = useState( false );
+	const [ hasRedo, setHasRedo ] = useState( false );
 
+	/**
+	 * Handle undo/redo state updates from PressThisEditor.
+	 *
+	 * @param {Object} state Undo state with handleUndo, handleRedo, hasUndo, hasRedo.
+	 */
 	const handleUndoReady = useCallback( ( state ) => {
-		setUndoState( state );
+		setUndoHandler( () => state.handleUndo );
+		setRedoHandler( () => state.handleRedo );
+		setHasUndo( state.hasUndo );
+		setHasRedo( state.hasRedo );
 	}, [] );
 
 	return (
@@ -340,10 +350,10 @@ export default function App() {
 				onSave={ saveState.handleSave }
 				isSaving={ saveState.isSaving }
 				publishLabel={ saveState.publishLabel }
-				onUndo={ undoState.handleUndo }
-				onRedo={ undoState.handleRedo }
-				hasUndo={ undoState.hasUndo }
-				hasRedo={ undoState.hasRedo }
+				onUndo={ undoHandler }
+				onRedo={ redoHandler }
+				hasUndo={ hasUndo }
+				hasRedo={ hasRedo }
 			/>
 
 			<div className="press-this-app__body">

--- a/src/App.js
+++ b/src/App.js
@@ -310,6 +310,18 @@ export default function App() {
 		setSaveState( state );
 	}, [] );
 
+	// State for undo/redo from editor.
+	const [ undoState, setUndoState ] = useState( {
+		handleUndo: null,
+		handleRedo: null,
+		hasUndo: false,
+		hasRedo: false,
+	} );
+
+	const handleUndoReady = useCallback( ( state ) => {
+		setUndoState( state );
+	}, [] );
+
 	return (
 		<div className="press-this-app">
 			<Header
@@ -328,6 +340,10 @@ export default function App() {
 				onSave={ saveState.handleSave }
 				isSaving={ saveState.isSaving }
 				publishLabel={ saveState.publishLabel }
+				onUndo={ undoState.handleUndo }
+				onRedo={ undoState.handleRedo }
+				hasUndo={ undoState.hasUndo }
+				hasRedo={ undoState.hasRedo }
 			/>
 
 			<div className="press-this-app__body">
@@ -344,6 +360,7 @@ export default function App() {
 					pendingScrape={ pendingScrape }
 					onScrapeProcessed={ handleScrapeProcessed }
 					onSaveReady={ handleSaveReady }
+					onUndoReady={ handleUndoReady }
 					categoryNonce={ data.categoryNonce || '' }
 					ajaxUrl={ data.ajaxUrl || '' }
 				/>

--- a/src/components/Header.js
+++ b/src/components/Header.js
@@ -12,7 +12,6 @@
  * WordPress dependencies
  */
 import { useState, useCallback, useEffect, useRef } from '@wordpress/element';
-import { useSelect, useDispatch } from '@wordpress/data';
 import {
 	Button,
 	TextControl,
@@ -28,7 +27,6 @@ import {
 	redo as redoIcon,
 	moreVertical,
 } from '@wordpress/icons';
-import { store as blockEditorStore } from '@wordpress/block-editor';
 
 /**
  * Internal dependencies
@@ -64,6 +62,10 @@ function isMacOS() {
  * @param {Function} props.onSave                Callback for save operations (status, options).
  * @param {boolean}  props.isSaving              Whether a save operation is in progress.
  * @param {string}   props.publishLabel          Label for the publish button.
+ * @param {Function} props.onUndo                Undo callback.
+ * @param {Function} props.onRedo                Redo callback.
+ * @param {boolean}  props.hasUndo               Whether undo is available.
+ * @param {boolean}  props.hasRedo               Whether redo is available.
  * @return {JSX.Element} Header component.
  */
 export default function Header( {
@@ -80,6 +82,10 @@ export default function Header( {
 	onSave,
 	isSaving = false,
 	publishLabel = __( 'Publish', 'press-this' ),
+	onUndo,
+	onRedo,
+	hasUndo = false,
+	hasRedo = false,
 } ) {
 	const [ scanUrl, setScanUrl ] = useState( sourceUrl || '' );
 	const [ isScanning, setIsScanning ] = useState( false );
@@ -89,25 +95,6 @@ export default function Header( {
 
 	// Track if initial auto-scan has been performed.
 	const hasAutoScanned = useRef( false );
-
-	// Undo/Redo state from block editor store.
-	// Note: These selectors require BlockEditorProvider context.
-	// If called outside context, they will return false/noop.
-	const { hasUndo, hasRedo } = useSelect( ( select ) => {
-		const store = select( blockEditorStore );
-		// Check if hasUndo/hasRedo exist (they might not if outside BlockEditorProvider context).
-		const canUndo =
-			typeof store.hasUndo === 'function' ? store.hasUndo() : false;
-		const canRedo =
-			typeof store.hasRedo === 'function' ? store.hasRedo() : false;
-		return {
-			hasUndo: canUndo,
-			hasRedo: canRedo,
-		};
-	}, [] );
-
-	// Undo/Redo actions from block editor store.
-	const { undo, redo } = useDispatch( blockEditorStore );
 
 	// Keyboard shortcut hints based on platform.
 	const undoShortcut = isMacOS() ? '\u2318Z' : 'Ctrl+Z';
@@ -329,7 +316,7 @@ export default function Header( {
 						<Button
 							className="press-this-header__toolbar-button"
 							icon={ undoIcon }
-							onClick={ undo }
+							onClick={ onUndo }
 							disabled={ ! hasUndo }
 							aria-label={ __( 'Undo', 'press-this' ) }
 						/>
@@ -343,7 +330,7 @@ export default function Header( {
 						<Button
 							className="press-this-header__toolbar-button"
 							icon={ redoIcon }
-							onClick={ redo }
+							onClick={ onRedo }
 							disabled={ ! hasRedo }
 							aria-label={ __( 'Redo', 'press-this' ) }
 						/>

--- a/src/components/PressThisEditor.js
+++ b/src/components/PressThisEditor.js
@@ -17,7 +17,7 @@ import {
 	useEffect,
 	useRef,
 } from '@wordpress/element';
-import { useSelect } from '@wordpress/data';
+import { useSelect, useDispatch } from '@wordpress/data';
 import { parse } from '@wordpress/blocks';
 import {
 	BlockEditorProvider,
@@ -275,6 +275,52 @@ export default function PressThisEditor( {
 	const [ tagSuggestions, setTagSuggestions ] = useState( [] );
 	const [ isLoadingTags, setIsLoadingTags ] = useState( false );
 	const tagSearchTimeout = useRef( null );
+
+	// Undo/Redo keyboard shortcuts.
+	// BlockEditorKeyboardShortcuts handles block-level shortcuts but not undo/redo.
+	// In full Gutenberg, EditorKeyboardShortcuts from @wordpress/editor registers these,
+	// but Press This uses BlockEditorProvider directly.
+	const { undo, redo } = useDispatch( blockEditorStore );
+
+	useEffect( () => {
+		function handleKeyDown( event ) {
+			// Don't override native undo in regular form fields (title, URL input, etc.).
+			const tagName = event.target.tagName.toLowerCase();
+			if (
+				tagName === 'input' ||
+				tagName === 'textarea' ||
+				tagName === 'select'
+			) {
+				return;
+			}
+
+			const isModKey = event.ctrlKey || event.metaKey;
+			if ( ! isModKey ) {
+				return;
+			}
+
+			const key = event.key.toLowerCase();
+
+			// Ctrl+Z / Cmd+Z = Undo, Ctrl+Shift+Z / Cmd+Shift+Z = Redo.
+			if ( key === 'z' ) {
+				event.preventDefault();
+				if ( event.shiftKey ) {
+					redo();
+				} else {
+					undo();
+				}
+			}
+
+			// Ctrl+Y / Cmd+Y = Redo (Windows/Linux convention).
+			if ( key === 'y' && ! event.shiftKey ) {
+				event.preventDefault();
+				redo();
+			}
+		}
+
+		document.addEventListener( 'keydown', handleKeyDown );
+		return () => document.removeEventListener( 'keydown', handleKeyDown );
+	}, [ undo, redo ] );
 
 	// Parse initial content.
 	useEffect( () => {

--- a/src/components/PressThisEditor.js
+++ b/src/components/PressThisEditor.js
@@ -17,7 +17,7 @@ import {
 	useEffect,
 	useRef,
 } from '@wordpress/element';
-import { useSelect, useDispatch } from '@wordpress/data';
+import { useSelect } from '@wordpress/data';
 import { parse } from '@wordpress/blocks';
 import {
 	BlockEditorProvider,
@@ -219,6 +219,7 @@ function getWpRestBaseUrl( pressThisRestUrl ) {
  * @param {Object}   props.pendingScrape     Pending scraped content to append.
  * @param {Function} props.onScrapeProcessed Callback after scrape is processed.
  * @param {Function} props.onSaveReady       Callback when save handler is ready (receives { handleSave, isSaving, publishLabel }).
+ * @param {Function} props.onUndoReady       Callback when undo/redo handlers are ready (receives { handleUndo, handleRedo, hasUndo, hasRedo }).
  * @param {string}   props.categoryNonce
  * @param {string}   props.ajaxUrl
  * @return {JSX.Element} Press This Editor component.
@@ -236,6 +237,7 @@ export default function PressThisEditor( {
 	pendingScrape = null,
 	onScrapeProcessed = () => {},
 	onSaveReady = () => {},
+	onUndoReady = () => {},
 	categoryNonce = '',
 	ajaxUrl = '',
 } ) {
@@ -276,12 +278,57 @@ export default function PressThisEditor( {
 	const [ isLoadingTags, setIsLoadingTags ] = useState( false );
 	const tagSearchTimeout = useRef( null );
 
-	// Undo/Redo keyboard shortcuts.
-	// BlockEditorKeyboardShortcuts handles block-level shortcuts but not undo/redo.
-	// In full Gutenberg, EditorKeyboardShortcuts from @wordpress/editor registers these,
-	// but Press This uses BlockEditorProvider directly.
-	const { undo, redo } = useDispatch( blockEditorStore );
+	// Undo/Redo stack.
+	// The core/block-editor store does not provide undo/redo actions.
+	// In full Gutenberg, EditorProvider manages undo via core-data entity edits,
+	// but Press This uses BlockEditorProvider directly with React state.
+	const undoStackRef = useRef( [] );
+	const redoStackRef = useRef( [] );
+	const blocksRef = useRef( blocks );
+	const isUndoingRef = useRef( false );
+	const [ hasUndo, setHasUndo ] = useState( false );
+	const [ hasRedo, setHasRedo ] = useState( false );
 
+	// Keep blocksRef in sync.
+	useEffect( () => {
+		blocksRef.current = blocks;
+	}, [ blocks ] );
+
+	const syncUndoRedoState = useCallback( () => {
+		setHasUndo( undoStackRef.current.length > 0 );
+		setHasRedo( redoStackRef.current.length > 0 );
+	}, [] );
+
+	const handleUndo = useCallback( () => {
+		if ( undoStackRef.current.length === 0 ) {
+			return;
+		}
+		const previousBlocks = undoStackRef.current.pop();
+		redoStackRef.current.push( blocksRef.current );
+		isUndoingRef.current = true;
+		setBlocks( previousBlocks );
+		syncUndoRedoState();
+	}, [ syncUndoRedoState ] );
+
+	const handleRedo = useCallback( () => {
+		if ( redoStackRef.current.length === 0 ) {
+			return;
+		}
+		const nextBlocks = redoStackRef.current.pop();
+		undoStackRef.current.push( blocksRef.current );
+		isUndoingRef.current = true;
+		setBlocks( nextBlocks );
+		syncUndoRedoState();
+	}, [ syncUndoRedoState ] );
+
+	// Expose undo/redo to parent (for Header buttons).
+	useEffect( () => {
+		if ( onUndoReady ) {
+			onUndoReady( { handleUndo, handleRedo, hasUndo, hasRedo } );
+		}
+	}, [ onUndoReady, handleUndo, handleRedo, hasUndo, hasRedo ] ); // eslint-disable-line react-hooks/exhaustive-deps
+
+	// Keyboard shortcuts for undo/redo.
 	useEffect( () => {
 		function handleKeyDown( event ) {
 			// Don't override native undo in regular form fields (title, URL input, etc.).
@@ -305,9 +352,9 @@ export default function PressThisEditor( {
 			if ( key === 'z' ) {
 				event.preventDefault();
 				if ( event.shiftKey ) {
-					redo();
+					handleRedo();
 				} else {
-					undo();
+					handleUndo();
 				}
 			}
 
@@ -319,13 +366,13 @@ export default function PressThisEditor( {
 				! event.metaKey
 			) {
 				event.preventDefault();
-				redo();
+				handleRedo();
 			}
 		}
 
 		document.addEventListener( 'keydown', handleKeyDown );
 		return () => document.removeEventListener( 'keydown', handleKeyDown );
-	}, [ undo, redo ] );
+	}, [ handleUndo, handleRedo ] );
 
 	// Parse initial content.
 	useEffect( () => {
@@ -347,10 +394,16 @@ export default function PressThisEditor( {
 			setTitle( pendingScrape.title );
 		}
 
-		// Parse and append the scraped content blocks.
+		// Parse and append the scraped content blocks (with undo level).
 		if ( pendingScrape.content ) {
 			const newBlocks = parse( pendingScrape.content );
+			undoStackRef.current = [
+				...undoStackRef.current,
+				blocksRef.current,
+			];
+			redoStackRef.current = [];
 			setBlocks( ( prevBlocks ) => [ ...prevBlocks, ...newBlocks ] );
+			syncUndoRedoState();
 		}
 
 		// Notify parent that we've processed the scrape.
@@ -358,13 +411,39 @@ export default function PressThisEditor( {
 	}, [ pendingScrape, onScrapeProcessed ] ); // eslint-disable-line react-hooks/exhaustive-deps
 
 	/**
-	 * Handle block changes.
+	 * Handle non-persistent block changes (e.g. typing).
+	 * Updates blocks without creating an undo level.
 	 *
 	 * @param {Array} newBlocks Updated blocks.
 	 */
-	const handleBlocksChange = useCallback( ( newBlocks ) => {
+	const handleBlocksInput = useCallback( ( newBlocks ) => {
 		setBlocks( newBlocks );
 	}, [] );
+
+	/**
+	 * Handle persistent block changes (e.g. paste, block operations).
+	 * Creates an undo level before applying the change.
+	 *
+	 * @param {Array} newBlocks Updated blocks.
+	 */
+	const handleBlocksChange = useCallback(
+		( newBlocks ) => {
+			// Don't create undo levels for undo/redo operations.
+			if ( isUndoingRef.current ) {
+				isUndoingRef.current = false;
+				setBlocks( newBlocks );
+				return;
+			}
+			undoStackRef.current = [
+				...undoStackRef.current,
+				blocksRef.current,
+			];
+			redoStackRef.current = [];
+			setBlocks( newBlocks );
+			syncUndoRedoState();
+		},
+		[ syncUndoRedoState ]
+	);
 
 	/**
 	 * Insert a block into the editor.
@@ -690,7 +769,7 @@ export default function PressThisEditor( {
 			<div className="press-this-editor">
 				<BlockEditorProvider
 					value={ blocks }
-					onInput={ handleBlocksChange }
+					onInput={ handleBlocksInput }
 					onChange={ handleBlocksChange }
 					settings={ editorSettings }
 				>

--- a/src/components/PressThisEditor.js
+++ b/src/components/PressThisEditor.js
@@ -469,6 +469,7 @@ export default function PressThisEditor( {
 				blocksRef.current,
 			];
 			redoStackRef.current = [];
+			blocksRef.current = newBlocks;
 			setBlocks( newBlocks );
 			syncUndoRedoState();
 		},

--- a/src/components/PressThisEditor.js
+++ b/src/components/PressThisEditor.js
@@ -308,6 +308,7 @@ export default function PressThisEditor( {
 		isUndoingRef.current = true;
 		blocksRef.current = previousBlocks;
 		setBlocks( previousBlocks );
+		isUndoingRef.current = false;
 		syncUndoRedoState();
 	}, [ syncUndoRedoState ] );
 
@@ -320,6 +321,7 @@ export default function PressThisEditor( {
 		isUndoingRef.current = true;
 		blocksRef.current = nextBlocks;
 		setBlocks( nextBlocks );
+		isUndoingRef.current = false;
 		syncUndoRedoState();
 	}, [ syncUndoRedoState ] );
 
@@ -328,7 +330,7 @@ export default function PressThisEditor( {
 		if ( onUndoReady ) {
 			onUndoReady( { handleUndo, handleRedo, hasUndo, hasRedo } );
 		}
-	}, [ onUndoReady, handleUndo, handleRedo, hasUndo, hasRedo ] ); // eslint-disable-line react-hooks/exhaustive-deps
+	}, [ onUndoReady, handleUndo, handleRedo, hasUndo, hasRedo ] );
 
 	// Keyboard shortcuts for undo/redo.
 	useEffect( () => {

--- a/src/components/PressThisEditor.js
+++ b/src/components/PressThisEditor.js
@@ -446,6 +446,7 @@ export default function PressThisEditor( {
 	 * @param {Array} newBlocks Updated blocks.
 	 */
 	const handleBlocksInput = useCallback( ( newBlocks ) => {
+		blocksRef.current = newBlocks;
 		setBlocks( newBlocks );
 	}, [] );
 

--- a/src/components/PressThisEditor.js
+++ b/src/components/PressThisEditor.js
@@ -306,6 +306,7 @@ export default function PressThisEditor( {
 		const previousBlocks = undoStackRef.current.pop();
 		redoStackRef.current.push( blocksRef.current );
 		isUndoingRef.current = true;
+		blocksRef.current = previousBlocks;
 		setBlocks( previousBlocks );
 		syncUndoRedoState();
 	}, [ syncUndoRedoState ] );
@@ -317,6 +318,7 @@ export default function PressThisEditor( {
 		const nextBlocks = redoStackRef.current.pop();
 		undoStackRef.current.push( blocksRef.current );
 		isUndoingRef.current = true;
+		blocksRef.current = nextBlocks;
 		setBlocks( nextBlocks );
 		syncUndoRedoState();
 	}, [ syncUndoRedoState ] );

--- a/src/components/PressThisEditor.js
+++ b/src/components/PressThisEditor.js
@@ -311,8 +311,13 @@ export default function PressThisEditor( {
 				}
 			}
 
-			// Ctrl+Y / Cmd+Y = Redo (Windows/Linux convention).
-			if ( key === 'y' && ! event.shiftKey ) {
+			// Ctrl+Y = Redo (Windows/Linux convention). Do not use Cmd+Y on macOS.
+			if (
+				key === 'y' &&
+				! event.shiftKey &&
+				event.ctrlKey &&
+				! event.metaKey
+			) {
 				event.preventDefault();
 				redo();
 			}

--- a/tests/components/undo-redo.test.js
+++ b/tests/components/undo-redo.test.js
@@ -1,0 +1,144 @@
+/**
+ * Undo/Redo Tests
+ *
+ * Tests the undo/redo implementation across Header.js (toolbar buttons)
+ * and PressThisEditor.js (undo stack + keyboard shortcuts).
+ *
+ * Follows the source-file string-matching pattern used by other component tests.
+ *
+ * @package press-this
+ */
+
+const fs = require( 'fs' );
+const path = require( 'path' );
+
+describe( 'Undo/Redo: Header toolbar buttons', () => {
+	let headerContent;
+
+	beforeAll( () => {
+		const headerPath = path.resolve(
+			__dirname,
+			'../../src/components/Header.js'
+		);
+		headerContent = fs.readFileSync( headerPath, 'utf8' );
+	} );
+
+	test( 'Header accepts onUndo, onRedo, hasUndo, hasRedo props', () => {
+		expect( headerContent ).toContain( 'onUndo' );
+		expect( headerContent ).toContain( 'onRedo' );
+		expect( headerContent ).toContain( 'hasUndo' );
+		expect( headerContent ).toContain( 'hasRedo' );
+	} );
+
+	test( 'Undo button is wired to onUndo and disabled when no undo available', () => {
+		expect( headerContent ).toContain( 'onClick={ onUndo }' );
+		expect( headerContent ).toContain( 'disabled={ ! hasUndo }' );
+	} );
+
+	test( 'Redo button is wired to onRedo and disabled when no redo available', () => {
+		expect( headerContent ).toContain( 'onClick={ onRedo }' );
+		expect( headerContent ).toContain( 'disabled={ ! hasRedo }' );
+	} );
+
+	test( 'Undo/redo icons imported from @wordpress/icons', () => {
+		expect( headerContent ).toMatch(
+			/import\s*\{[^}]*undo as undoIcon[^}]*\}\s*from\s*['"]@wordpress\/icons['"]/
+		);
+		expect( headerContent ).toMatch(
+			/import\s*\{[^}]*redo as redoIcon[^}]*\}\s*from\s*['"]@wordpress\/icons['"]/
+		);
+	} );
+
+	test( 'Buttons use the imported icons', () => {
+		expect( headerContent ).toContain( 'icon={ undoIcon }' );
+		expect( headerContent ).toContain( 'icon={ redoIcon }' );
+	} );
+} );
+
+describe( 'Undo/Redo: PressThisEditor stack and shortcuts', () => {
+	let editorContent;
+
+	beforeAll( () => {
+		const editorPath = path.resolve(
+			__dirname,
+			'../../src/components/PressThisEditor.js'
+		);
+		editorContent = fs.readFileSync( editorPath, 'utf8' );
+	} );
+
+	test( 'Undo/redo refs are declared', () => {
+		expect( editorContent ).toContain( 'undoStackRef' );
+		expect( editorContent ).toContain( 'redoStackRef' );
+		expect( editorContent ).toContain( 'isUndoingRef' );
+	} );
+
+	test( 'handleUndo and handleRedo callbacks are defined', () => {
+		expect( editorContent ).toMatch( /const\s+handleUndo\s*=\s*useCallback/ );
+		expect( editorContent ).toMatch( /const\s+handleRedo\s*=\s*useCallback/ );
+	} );
+
+	test( 'onUndoReady prop is accepted and called with handlers', () => {
+		// Prop in function signature.
+		expect( editorContent ).toContain( 'onUndoReady' );
+
+		// Called with the handler object.
+		expect( editorContent ).toMatch(
+			/onUndoReady\(\s*\{\s*handleUndo\s*,\s*handleRedo\s*,\s*hasUndo\s*,\s*hasRedo\s*\}\s*\)/
+		);
+	} );
+
+	test( 'Keyboard shortcut listener registered on document keydown', () => {
+		expect( editorContent ).toContain(
+			"document.addEventListener( 'keydown', handleKeyDown )"
+		);
+		expect( editorContent ).toContain(
+			"document.removeEventListener( 'keydown', handleKeyDown )"
+		);
+	} );
+
+	test( 'Form fields excluded from keyboard shortcuts', () => {
+		expect( editorContent ).toContain( "'input'" );
+		expect( editorContent ).toContain( "'textarea'" );
+		expect( editorContent ).toContain( "'select'" );
+	} );
+
+	test( 'Ctrl+Y restricted to ctrlKey && ! event.metaKey (Windows/Linux only)', () => {
+		expect( editorContent ).toMatch(
+			/key\s*===\s*'y'[\s\S]*?event\.ctrlKey[\s\S]*?!\s*event\.metaKey/
+		);
+	} );
+
+	test( 'isUndoingRef reset happens after setBlocks in handleUndo/handleRedo', () => {
+		// The fix ensures reset is AFTER setBlocks, not before.
+
+		// Check handleUndo ordering.
+		const handleUndoMatch = editorContent.match(
+			/const\s+handleUndo\s*=\s*useCallback\(\s*\(\)\s*=>\s*\{([\s\S]*?)\},\s*\[/
+		);
+		expect( handleUndoMatch ).not.toBeNull();
+
+		const undoBody = handleUndoMatch[ 1 ];
+		const setBlocksPosUndo = undoBody.indexOf( 'setBlocks(' );
+		const resetPosUndo = undoBody.lastIndexOf( 'isUndoingRef.current = false' );
+		expect( setBlocksPosUndo ).toBeGreaterThan( -1 );
+		expect( resetPosUndo ).toBeGreaterThan( setBlocksPosUndo );
+
+		// Check handleRedo ordering.
+		const handleRedoMatch = editorContent.match(
+			/const\s+handleRedo\s*=\s*useCallback\(\s*\(\)\s*=>\s*\{([\s\S]*?)\},\s*\[/
+		);
+		expect( handleRedoMatch ).not.toBeNull();
+
+		const redoBody = handleRedoMatch[ 1 ];
+		const setBlocksPosRedo = redoBody.indexOf( 'setBlocks(' );
+		const resetPosRedo = redoBody.lastIndexOf( 'isUndoingRef.current = false' );
+		expect( setBlocksPosRedo ).toBeGreaterThan( -1 );
+		expect( resetPosRedo ).toBeGreaterThan( setBlocksPosRedo );
+	} );
+
+	test( 'handleBlocksChange checks isUndoingRef to skip undo levels during undo/redo', () => {
+		expect( editorContent ).toMatch(
+			/handleBlocksChange[\s\S]*?isUndoingRef\.current/
+		);
+	} );
+} );


### PR DESCRIPTION
## Summary

- Register Ctrl+Z / Cmd+Z (undo), Ctrl+Shift+Z / Cmd+Shift+Z (redo), and Ctrl+Y (redo, Windows/Linux only) keyboard shortcuts in PressThisEditor
- Implements a custom undo/redo stack managed in React state, since the `core/block-editor` store does not expose undo/redo actions (in full Gutenberg, `EditorProvider` manages undo via `core-data` entity edits)
- Exposes undo/redo handlers to the Header component for toolbar button support
- Skips regular form fields (`<input>`, `<textarea>`, `<select>`) so native undo continues to work in the title input and URL scanner

Press This uses `BlockEditorProvider` directly rather than the full `EditorProvider` from `@wordpress/editor`. `BlockEditorKeyboardShortcuts` only registers block-level shortcuts (duplicate, remove, etc.) — not undo/redo. After paste, Gutenberg intercepts the event and processes it programmatically, which breaks the browser's native contentEditable undo stack. Without store-backed shortcuts, Ctrl+Z has nothing to dispatch.

Fixes #75

## Test plan

- [ ] Open Press This and type some text in the block editor
- [ ] Paste text into the editor (Ctrl+V / Cmd+V)
- [ ] Press Ctrl+Z / Cmd+Z — the paste should be undone
- [ ] Press Ctrl+Shift+Z / Cmd+Shift+Z — the paste should be redone
- [ ] On Windows/Linux, verify Ctrl+Y also redoes
- [ ] Type in the title field, then Ctrl+Z — native undo should still work there
- [ ] Verify the undo/redo toolbar buttons in the header still work