### PR TITLE
Fix scraped media inserting at bottom instead of cursor position

### DIFF
--- a/src/components/PressThisEditor.js
+++ b/src/components/PressThisEditor.js
@@ -17,7 +17,7 @@ import {
 	useEffect,
 	useRef,
 } from '@wordpress/element';
-import { useSelect } from '@wordpress/data';
+import { useSelect, useDispatch } from '@wordpress/data';
 import { parse } from '@wordpress/blocks';
 import {
 	BlockEditorProvider,
@@ -316,13 +316,19 @@ export default function PressThisEditor( {
 	}, [] );
 
 	/**
-	 * Insert a block into the editor.
+	 * Insert a block into the editor at the current selection point.
 	 *
-	 * @param {Object} block Block to insert.
+	 * Uses the block editor store's insertBlock action so the block is placed
+	 * after the currently selected block rather than always at the end.
 	 */
-	const insertBlock = useCallback( ( block ) => {
-		setBlocks( ( prev ) => [ ...prev, block ] );
-	}, [] );
+	const { insertBlock: dispatchInsertBlock } =
+		useDispatch( blockEditorStore );
+	const insertBlock = useCallback(
+		( block ) => {
+			dispatchInsertBlock( block );
+		},
+		[ dispatchInsertBlock ]
+	);
 
 	/**
 	 * Handle save operation.

--- a/src/components/PressThisEditor.js
+++ b/src/components/PressThisEditor.js
@@ -79,6 +79,31 @@ function SidebarBlockInspector() {
 	);
 }
 
+/**
+ * Connected Scraped Media Panel.
+ *
+ * Must be rendered inside BlockEditorProvider to access the block editor store.
+ * Uses the store's insertBlock action so media is inserted at the cursor
+ * position rather than always appended at the end.
+ *
+ * @param {Object} props Props passed through to ScrapedMediaPanel.
+ * @return {JSX.Element|null} ScrapedMediaPanel with store-connected insertion.
+ */
+function ConnectedScrapedMediaPanel( props ) {
+	const { insertBlock } = useDispatch( blockEditorStore );
+
+	const handleInsertBlock = useCallback(
+		( block ) => {
+			insertBlock( block );
+		},
+		[ insertBlock ]
+	);
+
+	return (
+		<ScrapedMediaPanel { ...props } onInsertBlock={ handleInsertBlock } />
+	);
+}
+
 // Ensure core blocks are registered.
 let blocksRegistered = false;
 function ensureBlocksRegistered() {
@@ -314,21 +339,6 @@ export default function PressThisEditor( {
 	const handleBlocksChange = useCallback( ( newBlocks ) => {
 		setBlocks( newBlocks );
 	}, [] );
-
-	/**
-	 * Insert a block into the editor at the current selection point.
-	 *
-	 * Uses the block editor store's insertBlock action so the block is placed
-	 * after the currently selected block rather than always at the end.
-	 */
-	const { insertBlock: dispatchInsertBlock } =
-		useDispatch( blockEditorStore );
-	const insertBlock = useCallback(
-		( block ) => {
-			dispatchInsertBlock( block );
-		},
-		[ dispatchInsertBlock ]
-	);
 
 	/**
 	 * Handle save operation.
@@ -752,10 +762,9 @@ export default function PressThisEditor( {
 									<SidebarBlockInspector />
 
 									{ /* Scraped Media Panel */ }
-									<ScrapedMediaPanel
+									<ConnectedScrapedMediaPanel
 										images={ images }
 										embeds={ embeds }
-										onInsertBlock={ insertBlock }
 										sourceUrl={ sourceUrl }
 									/>
 

--- a/tests/components/scraped-media-insertion.test.js
+++ b/tests/components/scraped-media-insertion.test.js
@@ -1,0 +1,59 @@
+/**
+ * Scraped Media Insertion Tests
+ *
+ * Verifies that inserting scraped media (images/embeds) from the sidebar
+ * uses the block editor store's insertBlock action, which respects cursor
+ * position, rather than manually appending to the blocks array.
+ *
+ * Regression test for https://github.com/WordPress/press-this/issues/76
+ *
+ * @package press-this
+ */
+
+const fs = require( 'fs' );
+const path = require( 'path' );
+
+describe( 'Scraped media insertion respects cursor position', () => {
+	let editorContent;
+
+	beforeAll( () => {
+		const editorPath = path.resolve(
+			__dirname,
+			'../../src/components/PressThisEditor.js'
+		);
+		editorContent = fs.readFileSync( editorPath, 'utf8' );
+	} );
+
+	test( 'useDispatch is imported from @wordpress/data', () => {
+		expect( editorContent ).toContain( 'useDispatch' );
+		expect( editorContent ).toMatch(
+			/import\s*\{[^}]*useDispatch[^}]*\}\s*from\s*['"]@wordpress\/data['"]/
+		);
+	} );
+
+	test( 'insertBlock is obtained from useDispatch( blockEditorStore )', () => {
+		expect( editorContent ).toMatch(
+			/useDispatch\(\s*blockEditorStore\s*\)/
+		);
+		expect( editorContent ).toContain( 'dispatchInsertBlock' );
+	} );
+
+	test( 'insertBlock callback delegates to dispatchInsertBlock', () => {
+		// The insertBlock callback should call dispatchInsertBlock, not setBlocks.
+		// Extract the insertBlock callback definition.
+		const insertBlockMatch = editorContent.match(
+			/const\s+insertBlock\s*=\s*useCallback\(\s*\n?\s*\(\s*block\s*\)\s*=>\s*\{([\s\S]*?)\},/
+		);
+		expect( insertBlockMatch ).not.toBeNull();
+
+		const callbackBody = insertBlockMatch[ 1 ];
+		expect( callbackBody ).toContain( 'dispatchInsertBlock' );
+		expect( callbackBody ).not.toContain( 'setBlocks' );
+	} );
+
+	test( 'ScrapedMediaPanel receives insertBlock as onInsertBlock prop', () => {
+		expect( editorContent ).toMatch(
+			/ScrapedMediaPanel[\s\S]*?onInsertBlock=\{\s*insertBlock\s*\}/
+		);
+	} );
+} );

--- a/tests/components/scraped-media-insertion.test.js
+++ b/tests/components/scraped-media-insertion.test.js
@@ -30,14 +30,14 @@ describe( 'Scraped media insertion respects cursor position', () => {
 		);
 	} );
 
-	test( 'a wrapper component uses useDispatch( blockEditorStore ) for insertion', () => {
+	test( 'ConnectedScrapedMediaPanel dispatches insertBlock via blockEditorStore', () => {
 		// The store dispatch must happen inside a child component rendered
 		// within BlockEditorProvider, not in PressThisEditor itself.
 		expect( editorContent ).toMatch(
 			/function\s+ConnectedScrapedMediaPanel/
 		);
 		expect( editorContent ).toMatch(
-			/useDispatch\(\s*blockEditorStore\s*\)/
+			/const\s+\{\s*insertBlock\s*\}\s*=\s*useDispatch\(\s*blockEditorStore\s*\)/
 		);
 	} );
 

--- a/tests/components/scraped-media-insertion.test.js
+++ b/tests/components/scraped-media-insertion.test.js
@@ -25,35 +25,38 @@ describe( 'Scraped media insertion respects cursor position', () => {
 	} );
 
 	test( 'useDispatch is imported from @wordpress/data', () => {
-		expect( editorContent ).toContain( 'useDispatch' );
 		expect( editorContent ).toMatch(
 			/import\s*\{[^}]*useDispatch[^}]*\}\s*from\s*['"]@wordpress\/data['"]/
 		);
 	} );
 
-	test( 'insertBlock is obtained from useDispatch( blockEditorStore )', () => {
+	test( 'a wrapper component uses useDispatch( blockEditorStore ) for insertion', () => {
+		// The store dispatch must happen inside a child component rendered
+		// within BlockEditorProvider, not in PressThisEditor itself.
+		expect( editorContent ).toMatch(
+			/function\s+ConnectedScrapedMediaPanel/
+		);
 		expect( editorContent ).toMatch(
 			/useDispatch\(\s*blockEditorStore\s*\)/
 		);
-		expect( editorContent ).toContain( 'dispatchInsertBlock' );
 	} );
 
-	test( 'insertBlock callback delegates to dispatchInsertBlock', () => {
-		// The insertBlock callback should call dispatchInsertBlock, not setBlocks.
-		// Extract the insertBlock callback definition.
-		const insertBlockMatch = editorContent.match(
-			/const\s+insertBlock\s*=\s*useCallback\(\s*\n?\s*\(\s*block\s*\)\s*=>\s*\{([\s\S]*?)\},/
+	test( 'ConnectedScrapedMediaPanel is used inside BlockEditorProvider JSX', () => {
+		// The connected wrapper should appear in the rendered JSX.
+		expect( editorContent ).toMatch( /<ConnectedScrapedMediaPanel/ );
+
+		// The raw ScrapedMediaPanel should NOT be rendered directly with
+		// a manual onInsertBlock in the main component's JSX.
+		expect( editorContent ).not.toMatch(
+			/<ScrapedMediaPanel[\s\S]*?onInsertBlock=\{[^}]*setBlocks/
 		);
-		expect( insertBlockMatch ).not.toBeNull();
-
-		const callbackBody = insertBlockMatch[ 1 ];
-		expect( callbackBody ).toContain( 'dispatchInsertBlock' );
-		expect( callbackBody ).not.toContain( 'setBlocks' );
 	} );
 
-	test( 'ScrapedMediaPanel receives insertBlock as onInsertBlock prop', () => {
-		expect( editorContent ).toMatch(
-			/ScrapedMediaPanel[\s\S]*?onInsertBlock=\{\s*insertBlock\s*\}/
+	test( 'no manual array-append insertion pattern exists', () => {
+		// The old bug: setBlocks( ( prev ) => [ ...prev, block ] ) for insertion.
+		// This pattern should not appear tied to an insertBlock callback.
+		expect( editorContent ).not.toMatch(
+			/insertBlock[\s\S]*?setBlocks\s*\(\s*\(\s*prev\s*\)\s*=>\s*\[\s*\.\.\.prev\s*,\s*block\s*\]/
 		);
 	} );
 } );


### PR DESCRIPTION
## Summary

- Use the block editor store's `insertBlock` dispatch action instead of manually appending to the blocks array, so scraped media inserts after the currently selected block rather than always at the end
- Add regression test verifying the insertion delegates to the store dispatch

## Test plan

- [ ] Open Press This with a source URL that has scraped images
- [ ] Place the cursor in the middle of existing content (e.g., between two paragraph blocks)
- [ ] Click a scraped image in the sidebar panel
- [ ] Verify the image block is inserted at the cursor position, not at the bottom
- [ ] Verify inserting with no block selected still appends at the end
- [ ] Run `npm run test:js` — all 9 suites should pass

Fixes #76