### PR TITLE
Register rich text format keyboard shortcuts

### DIFF
--- a/docs/keyboard-shortcuts.md
+++ b/docs/keyboard-shortcuts.md
@@ -1,0 +1,77 @@
+# Keyboard Shortcuts
+
+Press This uses `BlockEditorProvider` directly rather than the full Gutenberg `EditorProvider`. This means not all keyboard shortcuts from the standard WordPress editor are available. This document tracks what's supported and what isn't.
+
+Modifier key conventions: "Primary" is Ctrl on Windows/Linux, Cmd on macOS. "Access" is Ctrl+Alt on Windows/Linux, Ctrl+Option on macOS. "Secondary" is Ctrl+Shift on Windows/Linux, Cmd+Shift on macOS.
+
+## Rich Text Format Shortcuts
+
+Provided by `@wordpress/format-library`. These work inside any rich text block (paragraphs, headings, quotes, lists).
+
+| Shortcut | Action | Status |
+|----------|--------|--------|
+| Primary+B | Bold | Available |
+| Primary+I | Italic | Available |
+| Primary+K | Insert/edit link | Available |
+| Primary+Shift+K | Remove link | Available |
+| Primary+U | Underline | Available |
+| Access+D | Strikethrough | Available |
+| Access+X | Inline code | Available |
+
+## Block Editing Shortcuts
+
+Provided by `BlockEditorKeyboardShortcuts` from `@wordpress/block-editor`. These operate on selected blocks.
+
+| Shortcut | Action | Status |
+|----------|--------|--------|
+| Primary+A | Select all text, then all blocks | Available |
+| Primary+C | Copy selected block(s) | Available |
+| Primary+X | Cut selected block(s) | Available |
+| Primary+V | Paste | Available |
+| Primary+Shift+D | Duplicate selected block(s) | Available |
+| Access+Z | Remove selected block(s) | Available |
+| Primary+Alt+V | Paste styles | Available |
+| Primary+Alt+T | Insert block before | Available |
+| Primary+Alt+Y | Insert block after | Available |
+| Secondary+T | Move block up | Available |
+| Secondary+Y | Move block down | Available |
+| Primary+G | Group selected blocks | Available |
+| Primary+Shift+H | Toggle block visibility | Available |
+| Primary+Alt+R | Rename block | Available |
+| Escape | Clear selection / stop editing | Available |
+| Alt+F10 | Focus toolbar | Available |
+| / | Open block inserter (in empty paragraph) | Available |
+
+## Block Transform Shortcuts
+
+Provided by `@wordpress/block-library`. These convert between block types.
+
+| Shortcut | Action | Status |
+|----------|--------|--------|
+| Access+0 | Transform to paragraph | Available |
+| Access+1 through Access+6 | Transform to heading (level 1-6) | Available |
+| Access+7 | Transform to paragraph (alias) | Available |
+
+## Editor-Level Shortcuts (Not Available)
+
+These shortcuts are registered by `EditorKeyboardShortcuts` in `@wordpress/editor`, which Press This doesn't use. Some are handled through alternative implementations.
+
+| Shortcut | Action | Status | Notes |
+|----------|--------|--------|-------|
+| Primary+Z | Undo | Not available | See [#75](https://github.com/WordPress/press-this/issues/75), [PR #78](https://github.com/WordPress/press-this/pull/78) |
+| Primary+Shift+Z | Redo | Not available | See [#75](https://github.com/WordPress/press-this/issues/75), [PR #78](https://github.com/WordPress/press-this/pull/78) |
+| Primary+Y | Redo (Windows/Linux) | Not available | See [#75](https://github.com/WordPress/press-this/issues/75), [PR #78](https://github.com/WordPress/press-this/pull/78) |
+| Primary+S | Save | Not available | |
+| Secondary+M | Toggle code editor | Not available | Not applicable to Press This |
+| Access+O | Toggle list view | Not available | |
+| Primary+Shift+, | Toggle settings panel | Not available | |
+| Primary+Shift+\ | Distraction-free mode | Not available | |
+| Access+H | Show keyboard shortcuts | Not available | |
+
+## Legacy Shortcuts (Not Available)
+
+These shortcuts existed in the classic TinyMCE editor but were never part of the block editor.
+
+| Shortcut | Action | Notes |
+|----------|--------|-------|
+| Ctrl+Alt+Q | Toggle blockquote | Classic editor only. In the block editor, use Access+0 to transform to paragraph or the block toolbar to convert to a quote block. See [#81](https://github.com/WordPress/press-this/issues/81). |

--- a/package-lock.json
+++ b/package-lock.json
@@ -20,6 +20,7 @@
         "@wordpress/edit-post": "^8.37.0",
         "@wordpress/editor": "^14.37.0",
         "@wordpress/element": "^6.37.0",
+        "@wordpress/format-library": "^5.37.0",
         "@wordpress/i18n": "^6.10.0",
         "@wordpress/icons": "^11.4.0",
         "@wordpress/rich-text": "^7.37.0"
@@ -2048,6 +2049,72 @@
         "node": ">=6.9.0"
       }
     },
+    "node_modules/@base-ui/react": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@base-ui/react/-/react-1.2.0.tgz",
+      "integrity": "sha512-O6aEQHcm+QyGTFY28xuwRD3SEJGZOBDpyjN2WvpfWYFVhg+3zfXPysAILqtM0C1kWC82MccOE/v1j+GHXE4qIw==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.28.6",
+        "@base-ui/utils": "0.2.5",
+        "@floating-ui/react-dom": "^2.1.6",
+        "@floating-ui/utils": "^0.2.10",
+        "tabbable": "^6.4.0",
+        "use-sync-external-store": "^1.6.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/mui-org"
+      },
+      "peerDependencies": {
+        "@types/react": "^17 || ^18 || ^19",
+        "react": "^17 || ^18 || ^19",
+        "react-dom": "^17 || ^18 || ^19"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@base-ui/react/node_modules/@floating-ui/react-dom": {
+      "version": "2.1.7",
+      "resolved": "https://registry.npmjs.org/@floating-ui/react-dom/-/react-dom-2.1.7.tgz",
+      "integrity": "sha512-0tLRojf/1Go2JgEVm+3Frg9A3IW8bJgKgdO0BN5RkF//ufuz2joZM63Npau2ff3J6lUVYgDSNzNkR+aH3IVfjg==",
+      "license": "MIT",
+      "dependencies": {
+        "@floating-ui/dom": "^1.7.5"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0",
+        "react-dom": ">=16.8.0"
+      }
+    },
+    "node_modules/@base-ui/utils": {
+      "version": "0.2.5",
+      "resolved": "https://registry.npmjs.org/@base-ui/utils/-/utils-0.2.5.tgz",
+      "integrity": "sha512-oYC7w0gp76RI5MxprlGLV0wze0SErZaRl3AAkeP3OnNB/UBMb6RqNf6ZSIlxOc9Qp68Ab3C2VOcJQyRs7Xc7Vw==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.28.6",
+        "@floating-ui/utils": "^0.2.10",
+        "reselect": "^5.1.1",
+        "use-sync-external-store": "^1.6.0"
+      },
+      "peerDependencies": {
+        "@types/react": "^17 || ^18 || ^19",
+        "react": "^17 || ^18 || ^19",
+        "react-dom": "^17 || ^18 || ^19"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@bcoe/v8-coverage": {
       "version": "0.2.3",
       "resolved": "https://registry.npmjs.org/@bcoe/v8-coverage/-/v8-coverage-0.2.3.tgz",
@@ -2059,7 +2126,7 @@
       "version": "2.0.7",
       "resolved": "https://registry.npmjs.org/@cacheable/memory/-/memory-2.0.7.tgz",
       "integrity": "sha512-RbxnxAMf89Tp1dLhXMS7ceft/PGsDl1Ip7T20z5nZ+pwIAsQ1p2izPjVG69oCLv/jfQ7HDPHTWK0c9rcAWXN3A==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@cacheable/utils": "^2.3.3",
@@ -2072,7 +2139,7 @@
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/@keyv/bigmap/-/bigmap-1.3.0.tgz",
       "integrity": "sha512-KT01GjzV6AQD5+IYrcpoYLkCu1Jod3nau1Z7EsEuViO3TZGRacSbO9MfHmbJ1WaOXFtWLxPVj169cn2WNKPkIg==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "hashery": "^1.2.0",
@@ -2089,7 +2156,7 @@
       "version": "5.5.5",
       "resolved": "https://registry.npmjs.org/keyv/-/keyv-5.5.5.tgz",
       "integrity": "sha512-FA5LmZVF1VziNc0bIdCSA1IoSVnDCqE8HJIZZv2/W8YmoAM50+tnUgJR/gQZwEeIMleuIOnRnHA/UaZRNeV4iQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@keyv/serialize": "^1.1.1"
@@ -2099,7 +2166,7 @@
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/@cacheable/utils/-/utils-2.3.3.tgz",
       "integrity": "sha512-JsXDL70gQ+1Vc2W/KUFfkAJzgb4puKwwKehNLuB+HrNKWf91O736kGfxn4KujXCCSuh6mRRL4XEB0PkAFjWS0A==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "hashery": "^1.3.0",
@@ -2110,7 +2177,7 @@
       "version": "5.5.5",
       "resolved": "https://registry.npmjs.org/keyv/-/keyv-5.5.5.tgz",
       "integrity": "sha512-FA5LmZVF1VziNc0bIdCSA1IoSVnDCqE8HJIZZv2/W8YmoAM50+tnUgJR/gQZwEeIMleuIOnRnHA/UaZRNeV4iQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@keyv/serialize": "^1.1.1"
@@ -2192,7 +2259,7 @@
       "version": "3.0.5",
       "resolved": "https://registry.npmjs.org/@csstools/css-parser-algorithms/-/css-parser-algorithms-3.0.5.tgz",
       "integrity": "sha512-DaDeUkXZKjdGhgYaHNJTV9pV7Y9B3b644jCLs9Upc3VeNGg6LWARAT6O+Q+/COo+2gg/bM5rhpMAtf70WqfBdQ==",
-      "dev": true,
+      "devOptional": true,
       "funding": [
         {
           "type": "github",
@@ -2215,7 +2282,7 @@
       "version": "1.0.25",
       "resolved": "https://registry.npmjs.org/@csstools/css-syntax-patches-for-csstree/-/css-syntax-patches-for-csstree-1.0.25.tgz",
       "integrity": "sha512-g0Kw9W3vjx5BEBAF8c5Fm2NcB/Fs8jJXh85aXqwEXiL+tqtOut07TWgyaGzAAfTM+gKckrrncyeGEZPcaRgm2Q==",
-      "dev": true,
+      "devOptional": true,
       "funding": [
         {
           "type": "github",
@@ -2235,7 +2302,7 @@
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/@csstools/css-tokenizer/-/css-tokenizer-3.0.4.tgz",
       "integrity": "sha512-Vd/9EVDiu6PPJt9yAh6roZP6El1xHrdvIVGjyBsHR0RYwNHgL7FJPyIIW4fANJNG6FtyZfvlRPpFI4ZM/lubvw==",
-      "dev": true,
+      "devOptional": true,
       "funding": [
         {
           "type": "github",
@@ -2301,7 +2368,7 @@
       "version": "4.2.1",
       "resolved": "https://registry.npmjs.org/@dual-bundle/import-meta-resolve/-/import-meta-resolve-4.2.1.tgz",
       "integrity": "sha512-id+7YRUgoUX6CgV0DtuhirQWodeeA7Lf4i2x71JS/vtA5pRb/hIGWlw+G6MeXvsM+MXrz0VAydTGElX1rAfgPg==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "funding": {
         "type": "github",
@@ -2637,21 +2704,21 @@
       }
     },
     "node_modules/@floating-ui/core": {
-      "version": "1.7.3",
-      "resolved": "https://registry.npmjs.org/@floating-ui/core/-/core-1.7.3.tgz",
-      "integrity": "sha512-sGnvb5dmrJaKEZ+LDIpguvdX3bDlEllmv4/ClQ9awcmCZrlx5jQyyMWFM5kBI+EyNOCDDiKk8il0zeuX3Zlg/w==",
+      "version": "1.7.4",
+      "resolved": "https://registry.npmjs.org/@floating-ui/core/-/core-1.7.4.tgz",
+      "integrity": "sha512-C3HlIdsBxszvm5McXlB8PeOEWfBhcGBTZGkGlWc2U0KFY5IwG5OQEuQ8rq52DZmcHDlPLd+YFBK+cZcytwIFWg==",
       "license": "MIT",
       "dependencies": {
         "@floating-ui/utils": "^0.2.10"
       }
     },
     "node_modules/@floating-ui/dom": {
-      "version": "1.7.4",
-      "resolved": "https://registry.npmjs.org/@floating-ui/dom/-/dom-1.7.4.tgz",
-      "integrity": "sha512-OOchDgh4F2CchOX94cRVqhvy7b3AFb+/rQXyswmzmGakRfkMgoWVjfnLWkRirfLEfuD4ysVW16eXzwt3jHIzKA==",
+      "version": "1.7.5",
+      "resolved": "https://registry.npmjs.org/@floating-ui/dom/-/dom-1.7.5.tgz",
+      "integrity": "sha512-N0bD2kIPInNHUHehXhMke1rBGs1dwqvC9O9KYMyyjK7iXt7GAhnro7UlcuYcGdS/yYOlq0MAVgrow8IbWJwyqg==",
       "license": "MIT",
       "dependencies": {
-        "@floating-ui/core": "^1.7.3",
+        "@floating-ui/core": "^1.7.4",
         "@floating-ui/utils": "^0.2.10"
       }
     },
@@ -3977,7 +4044,7 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/@keyv/serialize/-/serialize-1.1.1.tgz",
       "integrity": "sha512-dXn3FZhPv0US+7dtJsIi2R+c7qWYiReoEh5zUntWCf4oSpMNib8FDhSoed6m3QyZdx5hK7iLFkYk3rNxwt8vTA==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/@kwsites/file-exists": {
@@ -4031,7 +4098,7 @@
       "version": "2.1.5",
       "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
       "integrity": "sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@nodelib/fs.stat": "2.0.5",
@@ -4045,7 +4112,7 @@
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/@nodelib/fs.stat/-/fs.stat-2.0.5.tgz",
       "integrity": "sha512-RkhPPp2zrqDAQA/2jNhnztcPAlv64XdhIp7a7454A5ovI7Bukxgt7MX7udwAu3zg1DcpPU0rz3VV1SeaqvY4+A==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">= 8"
@@ -4055,7 +4122,7 @@
       "version": "1.2.8",
       "resolved": "https://registry.npmjs.org/@nodelib/fs.walk/-/fs.walk-1.2.8.tgz",
       "integrity": "sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@nodelib/fs.scandir": "2.1.5",
@@ -7638,13 +7705,13 @@
       }
     },
     "node_modules/@wordpress/a11y": {
-      "version": "4.37.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/a11y/-/a11y-4.37.0.tgz",
-      "integrity": "sha512-OxJL0sBNy2IwFkrLv0X9tOgmdHbvgVajciN8T73S6jTh96iOmdISSb3n+I9fc81X0BB03rv4dh8q6zBb/67U6A==",
+      "version": "4.40.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/a11y/-/a11y-4.40.0.tgz",
+      "integrity": "sha512-WhBuBgJTvanbBMNeflgCvwQLOU9ToITdYSzOvWg0kzz1i/e138NlCxrVpcXGUc6MQulduKhOWOtjizSdotaQRA==",
       "license": "GPL-2.0-or-later",
       "dependencies": {
-        "@wordpress/dom-ready": "^4.37.0",
-        "@wordpress/i18n": "^6.10.0"
+        "@wordpress/dom-ready": "^4.40.0",
+        "@wordpress/i18n": "^6.13.0"
       },
       "engines": {
         "node": ">=18.12.0",
@@ -7673,13 +7740,13 @@
       }
     },
     "node_modules/@wordpress/api-fetch": {
-      "version": "7.37.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/api-fetch/-/api-fetch-7.37.0.tgz",
-      "integrity": "sha512-BFxfDiVKydoDZN1evbdIHzUzbbbW+Clat+2AMPTH+illCD2RcCiascKUu8n0bqQy1JxyzA8Xsm8Arn9cSlOGwA==",
+      "version": "7.40.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/api-fetch/-/api-fetch-7.40.0.tgz",
+      "integrity": "sha512-u/PjrmuHlVo93u1FrUGJQNokMyc8RvC9o0mQboU8sLe9Hz288XSShdvY7hyZfroYtXGu81s/3KUHxUsTK4GGrA==",
       "license": "GPL-2.0-or-later",
       "dependencies": {
-        "@wordpress/i18n": "^6.10.0",
-        "@wordpress/url": "^4.37.0"
+        "@wordpress/i18n": "^6.13.0",
+        "@wordpress/url": "^4.40.0"
       },
       "engines": {
         "node": ">=18.12.0",
@@ -7687,9 +7754,9 @@
       }
     },
     "node_modules/@wordpress/autop": {
-      "version": "4.37.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/autop/-/autop-4.37.0.tgz",
-      "integrity": "sha512-i1T5i2tiG4USM52xgONDYjzJimJA+tMJX+cP+pcgepWcDFKE5WCU0tgQClLuilrHqGe5sykAWnH1QigCz3uLSg==",
+      "version": "4.40.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/autop/-/autop-4.40.0.tgz",
+      "integrity": "sha512-sAWp7WFtwZni5QtoxX1O5U9zFnpmm42k3e+70fSOK8HcXYzW9EgVp1029oIlFihhiDU6Tey3yLzUvnkH+26hEw==",
       "license": "GPL-2.0-or-later",
       "engines": {
         "node": ">=18.12.0",
@@ -7915,9 +7982,9 @@
       }
     },
     "node_modules/@wordpress/base-styles": {
-      "version": "6.13.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/base-styles/-/base-styles-6.13.0.tgz",
-      "integrity": "sha512-+APLd5GqzzJ/atVVs3LGPcCRRy8mVfVQi1QY+cseNAQbRe4LvsDarLbzkblWEwuksxgUGmVGDC3fDNxrwszJ2A==",
+      "version": "6.16.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/base-styles/-/base-styles-6.16.0.tgz",
+      "integrity": "sha512-g8eZCTULM9rdQMTYfp3U+bHjT6wTtyuo8BFE2PCwJmH60Lp6P4qjnaez1PDW2M3yujCPwDdQBIR8tPXrTAlC/A==",
       "license": "GPL-2.0-or-later",
       "engines": {
         "node": ">=18.12.0",
@@ -7925,9 +7992,9 @@
       }
     },
     "node_modules/@wordpress/blob": {
-      "version": "4.37.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/blob/-/blob-4.37.0.tgz",
-      "integrity": "sha512-R0Dr8WkRKUszHNcif7zaCPUDmMSOOOsfC5as8kNMm8EKFPKh24FsB4LWryljafji2ZWwNPQ6x+eGUqpJwmMq9w==",
+      "version": "4.40.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/blob/-/blob-4.40.0.tgz",
+      "integrity": "sha512-25NNb+xCRudku6xtslOkwpAySRJyOFdFDDn1J3KUeAI7B9vsUppwRn1xPd4rcZuJ30DVuPZnvSRR9IXXjm3cIg==",
       "license": "GPL-2.0-or-later",
       "engines": {
         "node": ">=18.12.0",
@@ -7935,49 +8002,49 @@
       }
     },
     "node_modules/@wordpress/block-editor": {
-      "version": "15.10.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/block-editor/-/block-editor-15.10.0.tgz",
-      "integrity": "sha512-P8SXWUPEs3OovtlpbXJmC+4an0jolgdC+toaknOvNi1o3SAH44G8o4NYyXMgyhr5ub/+hsRQplEjInFJ/SZ+iA==",
+      "version": "15.13.1",
+      "resolved": "https://registry.npmjs.org/@wordpress/block-editor/-/block-editor-15.13.1.tgz",
+      "integrity": "sha512-7/APQjjuRYzfUUAvCZfU2lRYSZA35wAz2gUE6QK97AFhmDaAzOBdRCf8GdftiYLhRq+uuKdNzh1vyZ7ewKXF8A==",
       "license": "GPL-2.0-or-later",
       "dependencies": {
         "@react-spring/web": "^9.4.5",
-        "@wordpress/a11y": "^4.37.0",
-        "@wordpress/api-fetch": "^7.37.0",
-        "@wordpress/base-styles": "^6.13.0",
-        "@wordpress/blob": "^4.37.0",
-        "@wordpress/block-serialization-default-parser": "^5.37.0",
-        "@wordpress/blocks": "^15.10.0",
-        "@wordpress/commands": "^1.37.0",
-        "@wordpress/components": "^31.0.0",
-        "@wordpress/compose": "^7.37.0",
-        "@wordpress/data": "^10.37.0",
-        "@wordpress/dataviews": "^11.1.0",
-        "@wordpress/date": "^5.37.0",
-        "@wordpress/deprecated": "^4.37.0",
-        "@wordpress/dom": "^4.37.0",
-        "@wordpress/element": "^6.37.0",
-        "@wordpress/escape-html": "^3.37.0",
-        "@wordpress/global-styles-engine": "^1.4.0",
-        "@wordpress/hooks": "^4.37.0",
-        "@wordpress/html-entities": "^4.37.0",
-        "@wordpress/i18n": "^6.10.0",
-        "@wordpress/icons": "^11.4.0",
-        "@wordpress/image-cropper": "^1.1.0",
-        "@wordpress/interactivity": "^6.37.0",
-        "@wordpress/is-shallow-equal": "^5.37.0",
-        "@wordpress/keyboard-shortcuts": "^5.37.0",
-        "@wordpress/keycodes": "^4.37.0",
-        "@wordpress/notices": "^5.37.0",
-        "@wordpress/preferences": "^4.37.0",
-        "@wordpress/priority-queue": "^3.37.0",
-        "@wordpress/private-apis": "^1.37.0",
-        "@wordpress/rich-text": "^7.37.0",
-        "@wordpress/style-engine": "^2.37.0",
-        "@wordpress/token-list": "^3.37.0",
-        "@wordpress/upload-media": "^0.22.0",
-        "@wordpress/url": "^4.37.0",
-        "@wordpress/warning": "^3.37.0",
-        "@wordpress/wordcount": "^4.37.0",
+        "@wordpress/a11y": "^4.40.0",
+        "@wordpress/api-fetch": "^7.40.0",
+        "@wordpress/base-styles": "^6.16.0",
+        "@wordpress/blob": "^4.40.0",
+        "@wordpress/block-serialization-default-parser": "^5.40.0",
+        "@wordpress/blocks": "^15.13.0",
+        "@wordpress/commands": "^1.40.0",
+        "@wordpress/components": "^32.2.0",
+        "@wordpress/compose": "^7.40.0",
+        "@wordpress/data": "^10.40.0",
+        "@wordpress/dataviews": "^12.0.0",
+        "@wordpress/date": "^5.40.0",
+        "@wordpress/deprecated": "^4.40.0",
+        "@wordpress/dom": "^4.40.0",
+        "@wordpress/element": "^6.40.0",
+        "@wordpress/escape-html": "^3.40.0",
+        "@wordpress/global-styles-engine": "^1.7.0",
+        "@wordpress/hooks": "^4.40.0",
+        "@wordpress/html-entities": "^4.40.0",
+        "@wordpress/i18n": "^6.13.0",
+        "@wordpress/icons": "^11.7.0",
+        "@wordpress/image-cropper": "^1.4.0",
+        "@wordpress/interactivity": "^6.40.0",
+        "@wordpress/is-shallow-equal": "^5.40.0",
+        "@wordpress/keyboard-shortcuts": "^5.40.0",
+        "@wordpress/keycodes": "^4.40.0",
+        "@wordpress/notices": "^5.40.0",
+        "@wordpress/preferences": "^4.40.0",
+        "@wordpress/priority-queue": "^3.40.0",
+        "@wordpress/private-apis": "^1.40.0",
+        "@wordpress/rich-text": "^7.40.0",
+        "@wordpress/style-engine": "^2.40.0",
+        "@wordpress/token-list": "^3.40.0",
+        "@wordpress/upload-media": "^0.25.1",
+        "@wordpress/url": "^4.40.0",
+        "@wordpress/warning": "^3.40.0",
+        "@wordpress/wordcount": "^4.40.0",
         "change-case": "^4.1.2",
         "clsx": "^2.1.1",
         "colord": "^2.7.0",
@@ -8000,6 +8067,121 @@
       "peerDependencies": {
         "react": "^18.0.0",
         "react-dom": "^18.0.0"
+      }
+    },
+    "node_modules/@wordpress/block-editor/node_modules/@wordpress/components": {
+      "version": "32.2.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/components/-/components-32.2.0.tgz",
+      "integrity": "sha512-hfb8Yznykl83MCopXhNeVznP1/fpHAnQSgzF5IDfzC+VJLOqQkwjS4xUcmvLaSRN3xedYYvz1zlMbwnv2Fh8Nw==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "@ariakit/react": "^0.4.21",
+        "@date-fns/utc": "^2.1.1",
+        "@emotion/cache": "^11.14.0",
+        "@emotion/css": "^11.13.5",
+        "@emotion/react": "^11.14.0",
+        "@emotion/serialize": "^1.3.3",
+        "@emotion/styled": "^11.14.1",
+        "@emotion/utils": "^1.4.2",
+        "@floating-ui/react-dom": "2.0.8",
+        "@types/gradient-parser": "1.1.0",
+        "@types/highlight-words-core": "1.2.1",
+        "@types/react": "^18.3.27",
+        "@use-gesture/react": "^10.3.1",
+        "@wordpress/a11y": "^4.40.0",
+        "@wordpress/base-styles": "^6.16.0",
+        "@wordpress/compose": "^7.40.0",
+        "@wordpress/date": "^5.40.0",
+        "@wordpress/deprecated": "^4.40.0",
+        "@wordpress/dom": "^4.40.0",
+        "@wordpress/element": "^6.40.0",
+        "@wordpress/escape-html": "^3.40.0",
+        "@wordpress/hooks": "^4.40.0",
+        "@wordpress/html-entities": "^4.40.0",
+        "@wordpress/i18n": "^6.13.0",
+        "@wordpress/icons": "^11.7.0",
+        "@wordpress/is-shallow-equal": "^5.40.0",
+        "@wordpress/keycodes": "^4.40.0",
+        "@wordpress/primitives": "^4.40.0",
+        "@wordpress/private-apis": "^1.40.0",
+        "@wordpress/rich-text": "^7.40.0",
+        "@wordpress/warning": "^3.40.0",
+        "change-case": "^4.1.2",
+        "clsx": "^2.1.1",
+        "colord": "^2.7.0",
+        "csstype": "^3.2.3",
+        "date-fns": "^3.6.0",
+        "deepmerge": "^4.3.0",
+        "fast-deep-equal": "^3.1.3",
+        "framer-motion": "^11.15.0",
+        "gradient-parser": "1.1.1",
+        "highlight-words-core": "^1.2.2",
+        "is-plain-object": "^5.0.0",
+        "memize": "^2.1.0",
+        "path-to-regexp": "^6.2.1",
+        "re-resizable": "^6.4.0",
+        "react-colorful": "^5.6.1",
+        "react-day-picker": "^9.7.0",
+        "remove-accents": "^0.5.0",
+        "uuid": "^9.0.1"
+      },
+      "engines": {
+        "node": ">=18.12.0",
+        "npm": ">=8.19.2"
+      },
+      "peerDependencies": {
+        "react": "^18.0.0",
+        "react-dom": "^18.0.0"
+      }
+    },
+    "node_modules/@wordpress/block-editor/node_modules/@wordpress/dataviews": {
+      "version": "12.0.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/dataviews/-/dataviews-12.0.0.tgz",
+      "integrity": "sha512-DsG0SPNoMd5gKCIXE4zPf82pGLtcWMAeVTWxaSczRkvufwd7RA5qZdzeyztJZ+91KJ8vqqXw/fvTner0U9Pj6A==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "@ariakit/react": "^0.4.21",
+        "@wordpress/base-styles": "^6.16.0",
+        "@wordpress/components": "^32.2.0",
+        "@wordpress/compose": "^7.40.0",
+        "@wordpress/data": "^10.40.0",
+        "@wordpress/date": "^5.40.0",
+        "@wordpress/deprecated": "^4.40.0",
+        "@wordpress/dom": "^4.40.0",
+        "@wordpress/element": "^6.40.0",
+        "@wordpress/i18n": "^6.13.0",
+        "@wordpress/icons": "^11.7.0",
+        "@wordpress/keycodes": "^4.40.0",
+        "@wordpress/primitives": "^4.40.0",
+        "@wordpress/private-apis": "^1.40.0",
+        "@wordpress/theme": "^0.7.0",
+        "@wordpress/ui": "^0.7.0",
+        "@wordpress/url": "^4.40.0",
+        "@wordpress/warning": "^3.40.0",
+        "clsx": "^2.1.1",
+        "colord": "^2.7.0",
+        "date-fns": "^4.1.0",
+        "deepmerge": "4.3.1",
+        "fast-deep-equal": "^3.1.3",
+        "remove-accents": "^0.5.0"
+      },
+      "engines": {
+        "node": ">=18.12.0",
+        "npm": ">=8.19.2"
+      },
+      "peerDependencies": {
+        "react": "^18.0.0",
+        "react-dom": "^18.0.0"
+      }
+    },
+    "node_modules/@wordpress/block-editor/node_modules/@wordpress/dataviews/node_modules/date-fns": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-4.1.0.tgz",
+      "integrity": "sha512-Ukq0owbQXxa/U3EGtsdVBkR1w7KOQ5gIBqdH2hkvknzZPYvBxb/aa6E8L7tmjFtkwZBu3UXBbjIgPo/Ez4xaNg==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/kossnocorp"
       }
     },
     "node_modules/@wordpress/block-library": {
@@ -8063,9 +8245,9 @@
       }
     },
     "node_modules/@wordpress/block-serialization-default-parser": {
-      "version": "5.37.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/block-serialization-default-parser/-/block-serialization-default-parser-5.37.0.tgz",
-      "integrity": "sha512-fLUHChZv5sjbX+vkn2EJuEuUdAvCfx1tdmCuTi94O43/AsQc8u6sva7gtd59uttiJXKkLS9sPiM8oaoXCMb8Tw==",
+      "version": "5.40.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/block-serialization-default-parser/-/block-serialization-default-parser-5.40.0.tgz",
+      "integrity": "sha512-aAkE883BgNsV/sIua7VY0ifpbgUkDD/b98naWGCKnHCw2YIh1vWLNrjKlozsMyLVutuyW3w3agnYMKtXQc2uxg==",
       "license": "GPL-2.0-or-later",
       "engines": {
         "node": ">=18.12.0",
@@ -8073,26 +8255,26 @@
       }
     },
     "node_modules/@wordpress/blocks": {
-      "version": "15.10.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/blocks/-/blocks-15.10.0.tgz",
-      "integrity": "sha512-Bf5sp9QfifDpUsdjh5Vffjdt+SUfTAZJVFsEqN1GqB9Xfh0bXMXx0VtRjgqtdNdGd+0GX9WUhm3IVVizBCcyLw==",
+      "version": "15.13.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/blocks/-/blocks-15.13.0.tgz",
+      "integrity": "sha512-e1OEv472ZGi5zL154TWASO/wYxbH5845C42thbp9sBis1zB31bkUriIxpn2vqmJV22uFnh0L31uBLTkQAp5BiQ==",
       "license": "GPL-2.0-or-later",
       "dependencies": {
-        "@wordpress/autop": "^4.37.0",
-        "@wordpress/blob": "^4.37.0",
-        "@wordpress/block-serialization-default-parser": "^5.37.0",
-        "@wordpress/data": "^10.37.0",
-        "@wordpress/deprecated": "^4.37.0",
-        "@wordpress/dom": "^4.37.0",
-        "@wordpress/element": "^6.37.0",
-        "@wordpress/hooks": "^4.37.0",
-        "@wordpress/html-entities": "^4.37.0",
-        "@wordpress/i18n": "^6.10.0",
-        "@wordpress/is-shallow-equal": "^5.37.0",
-        "@wordpress/private-apis": "^1.37.0",
-        "@wordpress/rich-text": "^7.37.0",
-        "@wordpress/shortcode": "^4.37.0",
-        "@wordpress/warning": "^3.37.0",
+        "@wordpress/autop": "^4.40.0",
+        "@wordpress/blob": "^4.40.0",
+        "@wordpress/block-serialization-default-parser": "^5.40.0",
+        "@wordpress/data": "^10.40.0",
+        "@wordpress/deprecated": "^4.40.0",
+        "@wordpress/dom": "^4.40.0",
+        "@wordpress/element": "^6.40.0",
+        "@wordpress/hooks": "^4.40.0",
+        "@wordpress/html-entities": "^4.40.0",
+        "@wordpress/i18n": "^6.13.0",
+        "@wordpress/is-shallow-equal": "^5.40.0",
+        "@wordpress/private-apis": "^1.40.0",
+        "@wordpress/rich-text": "^7.40.0",
+        "@wordpress/shortcode": "^4.40.0",
+        "@wordpress/warning": "^3.40.0",
         "change-case": "^4.1.2",
         "colord": "^2.7.0",
         "fast-deep-equal": "^3.1.3",
@@ -8125,21 +8307,87 @@
       }
     },
     "node_modules/@wordpress/commands": {
-      "version": "1.37.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/commands/-/commands-1.37.0.tgz",
-      "integrity": "sha512-1oosAowqYxo0sQ7IyFfXeCsLEDQaZhx6eCpucMDH9IX8KtxudRfqYSc6StTfKR4kXntce4yBI4h9cA7UyX4zdA==",
+      "version": "1.40.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/commands/-/commands-1.40.0.tgz",
+      "integrity": "sha512-hqkXJoV/9NNctGZCO9VjyuXnT0yv0OaC8/XcW+Q3GX55laCEa2MXOgo3NdW5zqNY3PJqGdyO84RO9cG+lCtdiQ==",
       "license": "GPL-2.0-or-later",
       "dependencies": {
-        "@wordpress/base-styles": "^6.13.0",
-        "@wordpress/components": "^31.0.0",
-        "@wordpress/data": "^10.37.0",
-        "@wordpress/element": "^6.37.0",
-        "@wordpress/i18n": "^6.10.0",
-        "@wordpress/icons": "^11.4.0",
-        "@wordpress/keyboard-shortcuts": "^5.37.0",
-        "@wordpress/private-apis": "^1.37.0",
+        "@wordpress/base-styles": "^6.16.0",
+        "@wordpress/components": "^32.2.0",
+        "@wordpress/data": "^10.40.0",
+        "@wordpress/element": "^6.40.0",
+        "@wordpress/i18n": "^6.13.0",
+        "@wordpress/icons": "^11.7.0",
+        "@wordpress/keyboard-shortcuts": "^5.40.0",
+        "@wordpress/private-apis": "^1.40.0",
+        "@wordpress/warning": "^3.40.0",
         "clsx": "^2.1.1",
         "cmdk": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=18.12.0",
+        "npm": ">=8.19.2"
+      },
+      "peerDependencies": {
+        "react": "^18.0.0",
+        "react-dom": "^18.0.0"
+      }
+    },
+    "node_modules/@wordpress/commands/node_modules/@wordpress/components": {
+      "version": "32.2.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/components/-/components-32.2.0.tgz",
+      "integrity": "sha512-hfb8Yznykl83MCopXhNeVznP1/fpHAnQSgzF5IDfzC+VJLOqQkwjS4xUcmvLaSRN3xedYYvz1zlMbwnv2Fh8Nw==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "@ariakit/react": "^0.4.21",
+        "@date-fns/utc": "^2.1.1",
+        "@emotion/cache": "^11.14.0",
+        "@emotion/css": "^11.13.5",
+        "@emotion/react": "^11.14.0",
+        "@emotion/serialize": "^1.3.3",
+        "@emotion/styled": "^11.14.1",
+        "@emotion/utils": "^1.4.2",
+        "@floating-ui/react-dom": "2.0.8",
+        "@types/gradient-parser": "1.1.0",
+        "@types/highlight-words-core": "1.2.1",
+        "@types/react": "^18.3.27",
+        "@use-gesture/react": "^10.3.1",
+        "@wordpress/a11y": "^4.40.0",
+        "@wordpress/base-styles": "^6.16.0",
+        "@wordpress/compose": "^7.40.0",
+        "@wordpress/date": "^5.40.0",
+        "@wordpress/deprecated": "^4.40.0",
+        "@wordpress/dom": "^4.40.0",
+        "@wordpress/element": "^6.40.0",
+        "@wordpress/escape-html": "^3.40.0",
+        "@wordpress/hooks": "^4.40.0",
+        "@wordpress/html-entities": "^4.40.0",
+        "@wordpress/i18n": "^6.13.0",
+        "@wordpress/icons": "^11.7.0",
+        "@wordpress/is-shallow-equal": "^5.40.0",
+        "@wordpress/keycodes": "^4.40.0",
+        "@wordpress/primitives": "^4.40.0",
+        "@wordpress/private-apis": "^1.40.0",
+        "@wordpress/rich-text": "^7.40.0",
+        "@wordpress/warning": "^3.40.0",
+        "change-case": "^4.1.2",
+        "clsx": "^2.1.1",
+        "colord": "^2.7.0",
+        "csstype": "^3.2.3",
+        "date-fns": "^3.6.0",
+        "deepmerge": "^4.3.0",
+        "fast-deep-equal": "^3.1.3",
+        "framer-motion": "^11.15.0",
+        "gradient-parser": "1.1.1",
+        "highlight-words-core": "^1.2.2",
+        "is-plain-object": "^5.0.0",
+        "memize": "^2.1.0",
+        "path-to-regexp": "^6.2.1",
+        "re-resizable": "^6.4.0",
+        "react-colorful": "^5.6.1",
+        "react-day-picker": "^9.7.0",
+        "remove-accents": "^0.5.0",
+        "uuid": "^9.0.1"
       },
       "engines": {
         "node": ">=18.12.0",
@@ -8214,19 +8462,19 @@
       }
     },
     "node_modules/@wordpress/compose": {
-      "version": "7.37.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/compose/-/compose-7.37.0.tgz",
-      "integrity": "sha512-MF3HETEL/gd7AGZ8dmswZujx/vCUD2JtJEHDb0bW+h5JE4xi/RJOP+Nh5K4LxFS7wKBPga8yGU8m+8QXH44R+g==",
+      "version": "7.40.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/compose/-/compose-7.40.0.tgz",
+      "integrity": "sha512-u8LR5dxJd8KsiEv8eKG+aIgyRrp0lH0oOJy7cK9Jh721zc24TBu8vpxCADL7LbgmpPjQrjHh3LmPoCBtWL+FMg==",
       "license": "GPL-2.0-or-later",
       "dependencies": {
         "@types/mousetrap": "^1.6.8",
-        "@wordpress/deprecated": "^4.37.0",
-        "@wordpress/dom": "^4.37.0",
-        "@wordpress/element": "^6.37.0",
-        "@wordpress/is-shallow-equal": "^5.37.0",
-        "@wordpress/keycodes": "^4.37.0",
-        "@wordpress/priority-queue": "^3.37.0",
-        "@wordpress/undo-manager": "^1.37.0",
+        "@wordpress/deprecated": "^4.40.0",
+        "@wordpress/dom": "^4.40.0",
+        "@wordpress/element": "^6.40.0",
+        "@wordpress/is-shallow-equal": "^5.40.0",
+        "@wordpress/keycodes": "^4.40.0",
+        "@wordpress/priority-queue": "^3.40.0",
+        "@wordpress/undo-manager": "^1.40.0",
         "change-case": "^4.1.2",
         "clipboard": "^2.0.11",
         "mousetrap": "^1.6.5",
@@ -8278,18 +8526,18 @@
       }
     },
     "node_modules/@wordpress/data": {
-      "version": "10.37.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/data/-/data-10.37.0.tgz",
-      "integrity": "sha512-6bKkEoD5WR/lCmJogx9WxgldhMQPvgV1TlCIXhx6xp9uVzqjjgdRmSwZ8IJR13QQ9GGHn7vWb59GtW4lF2FMNA==",
+      "version": "10.40.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/data/-/data-10.40.0.tgz",
+      "integrity": "sha512-wwqkMc9iLteRO1zNxL/R3COWnijsdC5TIjenmd2JivReUmdA4ulAN3Tq7QiHkhwOV4jzZkuWW7DgR2ynxf55lw==",
       "license": "GPL-2.0-or-later",
       "dependencies": {
-        "@wordpress/compose": "^7.37.0",
-        "@wordpress/deprecated": "^4.37.0",
-        "@wordpress/element": "^6.37.0",
-        "@wordpress/is-shallow-equal": "^5.37.0",
-        "@wordpress/priority-queue": "^3.37.0",
-        "@wordpress/private-apis": "^1.37.0",
-        "@wordpress/redux-routine": "^5.37.0",
+        "@wordpress/compose": "^7.40.0",
+        "@wordpress/deprecated": "^4.40.0",
+        "@wordpress/element": "^6.40.0",
+        "@wordpress/is-shallow-equal": "^5.40.0",
+        "@wordpress/priority-queue": "^3.40.0",
+        "@wordpress/private-apis": "^1.40.0",
+        "@wordpress/redux-routine": "^5.40.0",
         "deepmerge": "^4.3.0",
         "equivalent-key-map": "^0.2.2",
         "is-plain-object": "^5.0.0",
@@ -8355,12 +8603,12 @@
       }
     },
     "node_modules/@wordpress/date": {
-      "version": "5.37.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/date/-/date-5.37.0.tgz",
-      "integrity": "sha512-T5YF5WLQu71bgw/KXhKcIqIRmAyf6nCq7J448MZlPIr0M9DAVPARXCOxYA4t/FW3PzwpFUARIuO2aNXTTO+nsA==",
+      "version": "5.40.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/date/-/date-5.40.0.tgz",
+      "integrity": "sha512-hlla3+3IVucwhFdOKFGnbeTf4XF0g6ZOdLvzDyTsXQqMT3/ozZ43e6uGwZdG7jrIbdIRicwwKONQsb8E4V6Cyw==",
       "license": "GPL-2.0-or-later",
       "dependencies": {
-        "@wordpress/deprecated": "^4.37.0",
+        "@wordpress/deprecated": "^4.40.0",
         "moment": "^2.29.4",
         "moment-timezone": "^0.5.40"
       },
@@ -8394,12 +8642,12 @@
       "license": "BSD"
     },
     "node_modules/@wordpress/deprecated": {
-      "version": "4.37.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/deprecated/-/deprecated-4.37.0.tgz",
-      "integrity": "sha512-QCV1akN9TXq7uRMsFQh0NyO4oHZvNP5NJWp1MSia1iqq8yLhMjcLaXVvMTnnJ2rQnVey0V0600f3BZZUyiZtEA==",
+      "version": "4.40.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/deprecated/-/deprecated-4.40.0.tgz",
+      "integrity": "sha512-/PAHeyxIlx/0J1jAfUS/v5x23ssMBXHtWNY3q/P8+GqmDkGTC/7SfkK9FFnT9aQecM1nK8vMgrgizicJBEzDdQ==",
       "license": "GPL-2.0-or-later",
       "dependencies": {
-        "@wordpress/hooks": "^4.37.0"
+        "@wordpress/hooks": "^4.40.0"
       },
       "engines": {
         "node": ">=18.12.0",
@@ -8407,12 +8655,12 @@
       }
     },
     "node_modules/@wordpress/dom": {
-      "version": "4.37.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/dom/-/dom-4.37.0.tgz",
-      "integrity": "sha512-OY78iz+3bkkjOygE7pZ8Z4gSIfm+d72W6WOx5/LCuaiCKfZN2RvKzbS9r9ML5/gGgeWmhTIbwSMx6YSBIBXsXw==",
+      "version": "4.40.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/dom/-/dom-4.40.0.tgz",
+      "integrity": "sha512-JBF1sRjJMFgLn0pet0tmPzO1kNaa35/DwAAtG81zzjikctR1PzE3EK8o6ZGPtUY1sTa9l7aB1Lxfcum/eroyRg==",
       "license": "GPL-2.0-or-later",
       "dependencies": {
-        "@wordpress/deprecated": "^4.37.0"
+        "@wordpress/deprecated": "^4.40.0"
       },
       "engines": {
         "node": ">=18.12.0",
@@ -8420,9 +8668,9 @@
       }
     },
     "node_modules/@wordpress/dom-ready": {
-      "version": "4.37.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/dom-ready/-/dom-ready-4.37.0.tgz",
-      "integrity": "sha512-igored8VegL2n/koKIyUhgPLhUfTa4N6zWO4gZpyeznr49M5wP/9Ak/tvIljUts9McHc2CVnCYMjZV0Zyz2aWg==",
+      "version": "4.40.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/dom-ready/-/dom-ready-4.40.0.tgz",
+      "integrity": "sha512-mHVy4P6yc0XLmGgnccxptMKg83TwcbYKfYrQH8pTcIu43P24zONTd44eZFjkfz7c/b+RLJg1Kj+d5mKh1xqH1A==",
       "license": "GPL-2.0-or-later",
       "engines": {
         "node": ">=18.12.0",
@@ -8564,14 +8812,14 @@
       }
     },
     "node_modules/@wordpress/element": {
-      "version": "6.37.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/element/-/element-6.37.0.tgz",
-      "integrity": "sha512-8+hvjtbsPX1Jz55a5uJi6o8jNOaGlAUwV55lUJsH+iE3OHA6PyE6r9atosGRRHvfXPDlKA5ckfbrtoh7h586GA==",
+      "version": "6.40.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/element/-/element-6.40.0.tgz",
+      "integrity": "sha512-OhU8B2xEGg7c41rh/VRiJLOz6TnM/r5r8sraAg5ISc2bF7s2oAFqLwvlR0/U6ervyYwbK644osWZGQxFyL3huA==",
       "license": "GPL-2.0-or-later",
       "dependencies": {
-        "@types/react": "^18.2.79",
-        "@types/react-dom": "^18.2.25",
-        "@wordpress/escape-html": "^3.37.0",
+        "@types/react": "^18.3.27",
+        "@types/react-dom": "^18.3.1",
+        "@wordpress/escape-html": "^3.40.0",
         "change-case": "^4.1.2",
         "is-plain-object": "^5.0.0",
         "react": "^18.3.0",
@@ -8611,9 +8859,9 @@
       }
     },
     "node_modules/@wordpress/escape-html": {
-      "version": "3.37.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/escape-html/-/escape-html-3.37.0.tgz",
-      "integrity": "sha512-hJ2yytDPaZ7Gx+Zj+1iUBzZYED+323MTFbkpydJecWA48K+cNyutEEuHPi9bzmJXirI0YSnkN5i1tZoYQPTiGQ==",
+      "version": "3.40.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/escape-html/-/escape-html-3.40.0.tgz",
+      "integrity": "sha512-DD6xWVbnw4fGGgO6DFDTJiLj52om0OG4cYHLz7ZhuipmOlEUGljPYOcrj8uxtlh5EFrqHCIPkOya+qQXUHUSBw==",
       "license": "GPL-2.0-or-later",
       "engines": {
         "node": ">=18.12.0",
@@ -8735,16 +8983,111 @@
         "react": "^18.0.0"
       }
     },
-    "node_modules/@wordpress/global-styles-engine": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/global-styles-engine/-/global-styles-engine-1.4.0.tgz",
-      "integrity": "sha512-gGwyqI3ntyeHQTRs8HRT2I+TrBWDU95mTp6y5n3FdTaya+Sl5fHVDdWs/MBcaZBipyLbp/TQVKKP1zM3FZHyLw==",
+    "node_modules/@wordpress/format-library": {
+      "version": "5.40.1",
+      "resolved": "https://registry.npmjs.org/@wordpress/format-library/-/format-library-5.40.1.tgz",
+      "integrity": "sha512-dXX7Owt+hO/EUCymVFr5VpH8F92HrsrvJGCIp1h0jAQS0/8/nLul6Xe22sAFVdlKkowz+eafungzgGJbTmN2TA==",
       "license": "GPL-2.0-or-later",
       "dependencies": {
-        "@wordpress/blocks": "^15.10.0",
-        "@wordpress/data": "^10.37.0",
-        "@wordpress/i18n": "^6.10.0",
-        "@wordpress/style-engine": "^2.37.0",
+        "@wordpress/a11y": "^4.40.0",
+        "@wordpress/base-styles": "^6.16.0",
+        "@wordpress/block-editor": "^15.13.1",
+        "@wordpress/components": "^32.2.0",
+        "@wordpress/compose": "^7.40.0",
+        "@wordpress/data": "^10.40.0",
+        "@wordpress/element": "^6.40.0",
+        "@wordpress/html-entities": "^4.40.0",
+        "@wordpress/i18n": "^6.13.0",
+        "@wordpress/icons": "^11.7.0",
+        "@wordpress/latex-to-mathml": "^1.8.0",
+        "@wordpress/private-apis": "^1.40.0",
+        "@wordpress/rich-text": "^7.40.0",
+        "@wordpress/url": "^4.40.0"
+      },
+      "engines": {
+        "node": ">=18.12.0",
+        "npm": ">=8.19.2"
+      },
+      "peerDependencies": {
+        "react": "^18.0.0",
+        "react-dom": "^18.0.0"
+      }
+    },
+    "node_modules/@wordpress/format-library/node_modules/@wordpress/components": {
+      "version": "32.2.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/components/-/components-32.2.0.tgz",
+      "integrity": "sha512-hfb8Yznykl83MCopXhNeVznP1/fpHAnQSgzF5IDfzC+VJLOqQkwjS4xUcmvLaSRN3xedYYvz1zlMbwnv2Fh8Nw==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "@ariakit/react": "^0.4.21",
+        "@date-fns/utc": "^2.1.1",
+        "@emotion/cache": "^11.14.0",
+        "@emotion/css": "^11.13.5",
+        "@emotion/react": "^11.14.0",
+        "@emotion/serialize": "^1.3.3",
+        "@emotion/styled": "^11.14.1",
+        "@emotion/utils": "^1.4.2",
+        "@floating-ui/react-dom": "2.0.8",
+        "@types/gradient-parser": "1.1.0",
+        "@types/highlight-words-core": "1.2.1",
+        "@types/react": "^18.3.27",
+        "@use-gesture/react": "^10.3.1",
+        "@wordpress/a11y": "^4.40.0",
+        "@wordpress/base-styles": "^6.16.0",
+        "@wordpress/compose": "^7.40.0",
+        "@wordpress/date": "^5.40.0",
+        "@wordpress/deprecated": "^4.40.0",
+        "@wordpress/dom": "^4.40.0",
+        "@wordpress/element": "^6.40.0",
+        "@wordpress/escape-html": "^3.40.0",
+        "@wordpress/hooks": "^4.40.0",
+        "@wordpress/html-entities": "^4.40.0",
+        "@wordpress/i18n": "^6.13.0",
+        "@wordpress/icons": "^11.7.0",
+        "@wordpress/is-shallow-equal": "^5.40.0",
+        "@wordpress/keycodes": "^4.40.0",
+        "@wordpress/primitives": "^4.40.0",
+        "@wordpress/private-apis": "^1.40.0",
+        "@wordpress/rich-text": "^7.40.0",
+        "@wordpress/warning": "^3.40.0",
+        "change-case": "^4.1.2",
+        "clsx": "^2.1.1",
+        "colord": "^2.7.0",
+        "csstype": "^3.2.3",
+        "date-fns": "^3.6.0",
+        "deepmerge": "^4.3.0",
+        "fast-deep-equal": "^3.1.3",
+        "framer-motion": "^11.15.0",
+        "gradient-parser": "1.1.1",
+        "highlight-words-core": "^1.2.2",
+        "is-plain-object": "^5.0.0",
+        "memize": "^2.1.0",
+        "path-to-regexp": "^6.2.1",
+        "re-resizable": "^6.4.0",
+        "react-colorful": "^5.6.1",
+        "react-day-picker": "^9.7.0",
+        "remove-accents": "^0.5.0",
+        "uuid": "^9.0.1"
+      },
+      "engines": {
+        "node": ">=18.12.0",
+        "npm": ">=8.19.2"
+      },
+      "peerDependencies": {
+        "react": "^18.0.0",
+        "react-dom": "^18.0.0"
+      }
+    },
+    "node_modules/@wordpress/global-styles-engine": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/global-styles-engine/-/global-styles-engine-1.7.0.tgz",
+      "integrity": "sha512-CGtsgrca3D7oeBWwZDfMh7v7vo31QYFg5HSrrydzF0rUEjr2qJnaTD8RtStqWd8ApbQ4cL1XsHL3r+xrxLvhUg==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "@wordpress/blocks": "^15.13.0",
+        "@wordpress/data": "^10.40.0",
+        "@wordpress/i18n": "^6.13.0",
+        "@wordpress/style-engine": "^2.40.0",
         "colord": "^2.9.2",
         "deepmerge": "^4.3.0",
         "fast-deep-equal": "^3.1.3",
@@ -8792,9 +9135,9 @@
       }
     },
     "node_modules/@wordpress/hooks": {
-      "version": "4.37.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/hooks/-/hooks-4.37.0.tgz",
-      "integrity": "sha512-MJpPAT7hQZS5JBnQm4/f5bHSETofGOw5zt7/mNoSEby5z3yTiIyEmBmzNo4Lu1xzIiU+g0OGmkBaOvn42LBibg==",
+      "version": "4.40.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/hooks/-/hooks-4.40.0.tgz",
+      "integrity": "sha512-Lz89uHQaMKM2TAdwafCPJr6px5qodZt/wdLmRrGkrItvtbikLdf9l29BrjpSMmRbJY6jiYtOTVF4sg5rwJv2Pw==",
       "license": "GPL-2.0-or-later",
       "engines": {
         "node": ">=18.12.0",
@@ -8802,9 +9145,9 @@
       }
     },
     "node_modules/@wordpress/html-entities": {
-      "version": "4.37.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/html-entities/-/html-entities-4.37.0.tgz",
-      "integrity": "sha512-d3uaAoGs20xpvdOTWlpTbxO4a8YwKYyBjoNhkL+w9qAg8NqLk9r2Z1pTj4EbYF9iS6SorDUdnXsTMuZ0/pm4Sw==",
+      "version": "4.40.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/html-entities/-/html-entities-4.40.0.tgz",
+      "integrity": "sha512-bsJrwZk22On8gNhUd84yyWKt/nrNZtACNZpXmkpyue/oTlFqNenLfhqRkvTKJzjbLxrrcUPsXlskbPcS7mxwTQ==",
       "license": "GPL-2.0-or-later",
       "engines": {
         "node": ">=18.12.0",
@@ -8812,13 +9155,13 @@
       }
     },
     "node_modules/@wordpress/i18n": {
-      "version": "6.10.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/i18n/-/i18n-6.10.0.tgz",
-      "integrity": "sha512-5tLAtnRQNxzA/d0GvVWCyo34Jb18w7xWTnup8hlh1+ehp7ZYTWR1QJihzVAteHoyrxAbTmzzsKyNtr8m+4ZpSQ==",
+      "version": "6.13.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/i18n/-/i18n-6.13.0.tgz",
+      "integrity": "sha512-Yx882uFxcg6QpB13fv8UhvM6k5NwMQGfNXKB9SVSNL/APvDWn2m/n4n+5GZYi+wOV+KJLojQZbdRpHWCnX/jFg==",
       "license": "GPL-2.0-or-later",
       "dependencies": {
         "@tannin/sprintf": "^1.3.2",
-        "@wordpress/hooks": "^4.37.0",
+        "@wordpress/hooks": "^4.40.0",
         "gettext-parser": "^1.3.1",
         "memize": "^2.1.0",
         "tannin": "^1.2.0"
@@ -8832,13 +9175,14 @@
       }
     },
     "node_modules/@wordpress/icons": {
-      "version": "11.4.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/icons/-/icons-11.4.0.tgz",
-      "integrity": "sha512-3sis5bwTyDOrLy83Mp799NNJuEgbTOWwHpxnGNmabEDA3BbBYPnr0soSGSFe201nqNKiVwL/TcpRaQ91SoEHTQ==",
+      "version": "11.7.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/icons/-/icons-11.7.0.tgz",
+      "integrity": "sha512-t+z65fn98A/Y4x+nynMQuJfz2v0sCfpsxa/+xopmOne/4Yt7H5/224sUc6zWV0NrIlWTDscD0QepUZ5j1qFM0Q==",
       "license": "GPL-2.0-or-later",
       "dependencies": {
-        "@wordpress/element": "^6.37.0",
-        "@wordpress/primitives": "^4.37.0"
+        "@wordpress/element": "^6.40.0",
+        "@wordpress/primitives": "^4.40.0",
+        "change-case": "4.1.2"
       },
       "engines": {
         "node": ">=18.12.0",
@@ -8849,12 +9193,14 @@
       }
     },
     "node_modules/@wordpress/image-cropper": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/image-cropper/-/image-cropper-1.1.0.tgz",
-      "integrity": "sha512-UT5f/8AdWxRo0wiEOpAeOk8UNdHJEXfNYy9MZ1kit7mG0o8WW7T8+0Rroktbz5wej4T38KYI3zDOMXGlBhr43g==",
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/image-cropper/-/image-cropper-1.4.0.tgz",
+      "integrity": "sha512-4Aedd2+eGwrxcVgSEK2GL1zHJVoSCQCKqQogYpnL3SGws8McuKrTpawLzbxCgQepwBL64UuNsZt39IKPtk/m4g==",
       "license": "GPL-2.0-or-later",
       "dependencies": {
-        "@wordpress/element": "^6.37.0",
+        "@wordpress/components": "^32.2.0",
+        "@wordpress/element": "^6.40.0",
+        "@wordpress/i18n": "^6.13.0",
         "clsx": "^2.1.1",
         "dequal": "^2.0.3",
         "react-easy-crop": "^5.4.2"
@@ -8862,12 +9208,81 @@
       "engines": {
         "node": ">=18.12.0",
         "npm": ">=8.19.2"
+      },
+      "peerDependencies": {
+        "react": "^18.0.0",
+        "react-dom": "^18.0.0"
+      }
+    },
+    "node_modules/@wordpress/image-cropper/node_modules/@wordpress/components": {
+      "version": "32.2.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/components/-/components-32.2.0.tgz",
+      "integrity": "sha512-hfb8Yznykl83MCopXhNeVznP1/fpHAnQSgzF5IDfzC+VJLOqQkwjS4xUcmvLaSRN3xedYYvz1zlMbwnv2Fh8Nw==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "@ariakit/react": "^0.4.21",
+        "@date-fns/utc": "^2.1.1",
+        "@emotion/cache": "^11.14.0",
+        "@emotion/css": "^11.13.5",
+        "@emotion/react": "^11.14.0",
+        "@emotion/serialize": "^1.3.3",
+        "@emotion/styled": "^11.14.1",
+        "@emotion/utils": "^1.4.2",
+        "@floating-ui/react-dom": "2.0.8",
+        "@types/gradient-parser": "1.1.0",
+        "@types/highlight-words-core": "1.2.1",
+        "@types/react": "^18.3.27",
+        "@use-gesture/react": "^10.3.1",
+        "@wordpress/a11y": "^4.40.0",
+        "@wordpress/base-styles": "^6.16.0",
+        "@wordpress/compose": "^7.40.0",
+        "@wordpress/date": "^5.40.0",
+        "@wordpress/deprecated": "^4.40.0",
+        "@wordpress/dom": "^4.40.0",
+        "@wordpress/element": "^6.40.0",
+        "@wordpress/escape-html": "^3.40.0",
+        "@wordpress/hooks": "^4.40.0",
+        "@wordpress/html-entities": "^4.40.0",
+        "@wordpress/i18n": "^6.13.0",
+        "@wordpress/icons": "^11.7.0",
+        "@wordpress/is-shallow-equal": "^5.40.0",
+        "@wordpress/keycodes": "^4.40.0",
+        "@wordpress/primitives": "^4.40.0",
+        "@wordpress/private-apis": "^1.40.0",
+        "@wordpress/rich-text": "^7.40.0",
+        "@wordpress/warning": "^3.40.0",
+        "change-case": "^4.1.2",
+        "clsx": "^2.1.1",
+        "colord": "^2.7.0",
+        "csstype": "^3.2.3",
+        "date-fns": "^3.6.0",
+        "deepmerge": "^4.3.0",
+        "fast-deep-equal": "^3.1.3",
+        "framer-motion": "^11.15.0",
+        "gradient-parser": "1.1.1",
+        "highlight-words-core": "^1.2.2",
+        "is-plain-object": "^5.0.0",
+        "memize": "^2.1.0",
+        "path-to-regexp": "^6.2.1",
+        "re-resizable": "^6.4.0",
+        "react-colorful": "^5.6.1",
+        "react-day-picker": "^9.7.0",
+        "remove-accents": "^0.5.0",
+        "uuid": "^9.0.1"
+      },
+      "engines": {
+        "node": ">=18.12.0",
+        "npm": ">=8.19.2"
+      },
+      "peerDependencies": {
+        "react": "^18.0.0",
+        "react-dom": "^18.0.0"
       }
     },
     "node_modules/@wordpress/interactivity": {
-      "version": "6.37.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/interactivity/-/interactivity-6.37.0.tgz",
-      "integrity": "sha512-xxXBu+j60POjCKo/9mFc6gKb7KfR8t0+vxUFJciuMVjuBnUT2Xyld+S4bhaAn9s8hjbANMwMIr7c7c6CVck9gw==",
+      "version": "6.40.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/interactivity/-/interactivity-6.40.0.tgz",
+      "integrity": "sha512-VYHZMKzg3w7pRG58aD+M1ZxyicDK9or6WJ3pcVXyp7WaGJrleJqd/jIFj4csIqLGW4kKozNq1NBaqjqVHOnIqA==",
       "license": "GPL-2.0-or-later",
       "dependencies": {
         "@preact/signals": "^1.3.0",
@@ -8923,9 +9338,9 @@
       }
     },
     "node_modules/@wordpress/is-shallow-equal": {
-      "version": "5.37.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/is-shallow-equal/-/is-shallow-equal-5.37.0.tgz",
-      "integrity": "sha512-aOW5Yw0uiuekmVb3KAkoWnCopBIOUOiL4XcSWAcSgRxUmtxOg6CE7M9mb5LTI35MUeQj0yay3NVyIXf5Z16LMA==",
+      "version": "5.40.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/is-shallow-equal/-/is-shallow-equal-5.40.0.tgz",
+      "integrity": "sha512-IU11xOcHIGqDLxx9X+8RIk4WFo0qqba0bpeLqrVKsQXNGjP7tXSo2ufylxE9K9CEYXFMF0C65k83XpRZtEkA8g==",
       "license": "GPL-2.0-or-later",
       "engines": {
         "node": ">=18.12.0",
@@ -8969,14 +9384,14 @@
       }
     },
     "node_modules/@wordpress/keyboard-shortcuts": {
-      "version": "5.37.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/keyboard-shortcuts/-/keyboard-shortcuts-5.37.0.tgz",
-      "integrity": "sha512-9IJFAYBbUQy2GLJGf0T1yBsOMfh5GuKkt+wvnWYqO1nTn1MqDu/YAibPQgv4a5Ftzc2jH6RuLlelaIepOEE4Qw==",
+      "version": "5.40.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/keyboard-shortcuts/-/keyboard-shortcuts-5.40.0.tgz",
+      "integrity": "sha512-E9EjZa1Dibo5YiRz6hoFx+ihlj5nqGkMc4ZF8LwpTbZLqsN8fG/SEdOwbkxFXqVQIBau6Csq484Ld2xtQ9wDHw==",
       "license": "GPL-2.0-or-later",
       "dependencies": {
-        "@wordpress/data": "^10.37.0",
-        "@wordpress/element": "^6.37.0",
-        "@wordpress/keycodes": "^4.37.0"
+        "@wordpress/data": "^10.40.0",
+        "@wordpress/element": "^6.40.0",
+        "@wordpress/keycodes": "^4.40.0"
       },
       "engines": {
         "node": ">=18.12.0",
@@ -8987,12 +9402,12 @@
       }
     },
     "node_modules/@wordpress/keycodes": {
-      "version": "4.37.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/keycodes/-/keycodes-4.37.0.tgz",
-      "integrity": "sha512-VPysLigCr6J15oMkI5YLbIM7n9D9uNTtbJpw8/SgX4gOaamfH3nH/hUJeV440JlshwX13p+hPILHq4zpOoBntg==",
+      "version": "4.40.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/keycodes/-/keycodes-4.40.0.tgz",
+      "integrity": "sha512-laLkfjwkhMdreCl/KQdHucBIQAYwSjkyk3BToq/PCrcxFJBwWK2NgEtSl/t1CEw2HJwe0H2ne3FEWtipY4iDrA==",
       "license": "GPL-2.0-or-later",
       "dependencies": {
-        "@wordpress/i18n": "^6.10.0"
+        "@wordpress/i18n": "^6.13.0"
       },
       "engines": {
         "node": ">=18.12.0",
@@ -9000,9 +9415,9 @@
       }
     },
     "node_modules/@wordpress/latex-to-mathml": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/latex-to-mathml/-/latex-to-mathml-1.5.0.tgz",
-      "integrity": "sha512-5+zLILxtAefUYUdvrhuQZ/0s6LTLi/2bQnD9ZuwlRLE2OpBuLvBI80f0YWPaP32oFz2qJ/Q9ZkmrbVYBV0URqA==",
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/latex-to-mathml/-/latex-to-mathml-1.8.0.tgz",
+      "integrity": "sha512-GfUKLJ48QUT+dmcUDZEhdG6rCakj4UXaNmUjnhUgIv0tWp+yu1cFXPFS/ojlqFP3H8t3OjJWKouPW8JQPyBlKw==",
       "license": "GPL-2.0-or-later",
       "dependencies": {
         "temml": "^0.10.33"
@@ -9063,13 +9478,15 @@
       }
     },
     "node_modules/@wordpress/notices": {
-      "version": "5.37.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/notices/-/notices-5.37.0.tgz",
-      "integrity": "sha512-b/bJSCXJR8wsdJQMcUxKIhodp6CwephHdUEEMGaZMbsU252m6gZ2FF2kH49XeQSNr4fTLQjRHWaZUpijApAzBA==",
+      "version": "5.40.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/notices/-/notices-5.40.0.tgz",
+      "integrity": "sha512-hn54Pa5kDk7sZZ0RihALYrxJ5RAOxANyfMqrPiGX7Yi5U+K+kWTio+WhPB+j6iq1+G9BXJS3dkouJk11RtbcKw==",
       "license": "GPL-2.0-or-later",
       "dependencies": {
-        "@wordpress/a11y": "^4.37.0",
-        "@wordpress/data": "^10.37.0"
+        "@wordpress/a11y": "^4.40.0",
+        "@wordpress/components": "^32.2.0",
+        "@wordpress/data": "^10.40.0",
+        "clsx": "^2.1.1"
       },
       "engines": {
         "node": ">=18.12.0",
@@ -9077,6 +9494,71 @@
       },
       "peerDependencies": {
         "react": "^18.0.0"
+      }
+    },
+    "node_modules/@wordpress/notices/node_modules/@wordpress/components": {
+      "version": "32.2.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/components/-/components-32.2.0.tgz",
+      "integrity": "sha512-hfb8Yznykl83MCopXhNeVznP1/fpHAnQSgzF5IDfzC+VJLOqQkwjS4xUcmvLaSRN3xedYYvz1zlMbwnv2Fh8Nw==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "@ariakit/react": "^0.4.21",
+        "@date-fns/utc": "^2.1.1",
+        "@emotion/cache": "^11.14.0",
+        "@emotion/css": "^11.13.5",
+        "@emotion/react": "^11.14.0",
+        "@emotion/serialize": "^1.3.3",
+        "@emotion/styled": "^11.14.1",
+        "@emotion/utils": "^1.4.2",
+        "@floating-ui/react-dom": "2.0.8",
+        "@types/gradient-parser": "1.1.0",
+        "@types/highlight-words-core": "1.2.1",
+        "@types/react": "^18.3.27",
+        "@use-gesture/react": "^10.3.1",
+        "@wordpress/a11y": "^4.40.0",
+        "@wordpress/base-styles": "^6.16.0",
+        "@wordpress/compose": "^7.40.0",
+        "@wordpress/date": "^5.40.0",
+        "@wordpress/deprecated": "^4.40.0",
+        "@wordpress/dom": "^4.40.0",
+        "@wordpress/element": "^6.40.0",
+        "@wordpress/escape-html": "^3.40.0",
+        "@wordpress/hooks": "^4.40.0",
+        "@wordpress/html-entities": "^4.40.0",
+        "@wordpress/i18n": "^6.13.0",
+        "@wordpress/icons": "^11.7.0",
+        "@wordpress/is-shallow-equal": "^5.40.0",
+        "@wordpress/keycodes": "^4.40.0",
+        "@wordpress/primitives": "^4.40.0",
+        "@wordpress/private-apis": "^1.40.0",
+        "@wordpress/rich-text": "^7.40.0",
+        "@wordpress/warning": "^3.40.0",
+        "change-case": "^4.1.2",
+        "clsx": "^2.1.1",
+        "colord": "^2.7.0",
+        "csstype": "^3.2.3",
+        "date-fns": "^3.6.0",
+        "deepmerge": "^4.3.0",
+        "fast-deep-equal": "^3.1.3",
+        "framer-motion": "^11.15.0",
+        "gradient-parser": "1.1.1",
+        "highlight-words-core": "^1.2.2",
+        "is-plain-object": "^5.0.0",
+        "memize": "^2.1.0",
+        "path-to-regexp": "^6.2.1",
+        "re-resizable": "^6.4.0",
+        "react-colorful": "^5.6.1",
+        "react-day-picker": "^9.7.0",
+        "remove-accents": "^0.5.0",
+        "uuid": "^9.0.1"
+      },
+      "engines": {
+        "node": ">=18.12.0",
+        "npm": ">=8.19.2"
+      },
+      "peerDependencies": {
+        "react": "^18.0.0",
+        "react-dom": "^18.0.0"
       }
     },
     "node_modules/@wordpress/npm-package-json-lint-config": {
@@ -9168,22 +9650,87 @@
       }
     },
     "node_modules/@wordpress/preferences": {
-      "version": "4.37.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/preferences/-/preferences-4.37.0.tgz",
-      "integrity": "sha512-+GOmfe+i47SA74zDi+j6jYxoI0sZv2056tDbf+uGBF8rOEceQaLEhs+24fY/shAJV3Umf09yltXph5kdfs05/w==",
+      "version": "4.40.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/preferences/-/preferences-4.40.0.tgz",
+      "integrity": "sha512-vs6p0jEFVJtA3K6YI8Wm2C1zOYYqcYYS1cJVApat/95VBORFcu7i8GZ1bg59tuxX1OFmxevrdIL8YnG8W9ZoLQ==",
       "license": "GPL-2.0-or-later",
       "dependencies": {
-        "@wordpress/a11y": "^4.37.0",
-        "@wordpress/base-styles": "^6.13.0",
-        "@wordpress/components": "^31.0.0",
-        "@wordpress/compose": "^7.37.0",
-        "@wordpress/data": "^10.37.0",
-        "@wordpress/deprecated": "^4.37.0",
-        "@wordpress/element": "^6.37.0",
-        "@wordpress/i18n": "^6.10.0",
-        "@wordpress/icons": "^11.4.0",
-        "@wordpress/private-apis": "^1.37.0",
+        "@wordpress/a11y": "^4.40.0",
+        "@wordpress/base-styles": "^6.16.0",
+        "@wordpress/components": "^32.2.0",
+        "@wordpress/compose": "^7.40.0",
+        "@wordpress/data": "^10.40.0",
+        "@wordpress/deprecated": "^4.40.0",
+        "@wordpress/element": "^6.40.0",
+        "@wordpress/i18n": "^6.13.0",
+        "@wordpress/icons": "^11.7.0",
+        "@wordpress/private-apis": "^1.40.0",
         "clsx": "^2.1.1"
+      },
+      "engines": {
+        "node": ">=18.12.0",
+        "npm": ">=8.19.2"
+      },
+      "peerDependencies": {
+        "react": "^18.0.0",
+        "react-dom": "^18.0.0"
+      }
+    },
+    "node_modules/@wordpress/preferences/node_modules/@wordpress/components": {
+      "version": "32.2.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/components/-/components-32.2.0.tgz",
+      "integrity": "sha512-hfb8Yznykl83MCopXhNeVznP1/fpHAnQSgzF5IDfzC+VJLOqQkwjS4xUcmvLaSRN3xedYYvz1zlMbwnv2Fh8Nw==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "@ariakit/react": "^0.4.21",
+        "@date-fns/utc": "^2.1.1",
+        "@emotion/cache": "^11.14.0",
+        "@emotion/css": "^11.13.5",
+        "@emotion/react": "^11.14.0",
+        "@emotion/serialize": "^1.3.3",
+        "@emotion/styled": "^11.14.1",
+        "@emotion/utils": "^1.4.2",
+        "@floating-ui/react-dom": "2.0.8",
+        "@types/gradient-parser": "1.1.0",
+        "@types/highlight-words-core": "1.2.1",
+        "@types/react": "^18.3.27",
+        "@use-gesture/react": "^10.3.1",
+        "@wordpress/a11y": "^4.40.0",
+        "@wordpress/base-styles": "^6.16.0",
+        "@wordpress/compose": "^7.40.0",
+        "@wordpress/date": "^5.40.0",
+        "@wordpress/deprecated": "^4.40.0",
+        "@wordpress/dom": "^4.40.0",
+        "@wordpress/element": "^6.40.0",
+        "@wordpress/escape-html": "^3.40.0",
+        "@wordpress/hooks": "^4.40.0",
+        "@wordpress/html-entities": "^4.40.0",
+        "@wordpress/i18n": "^6.13.0",
+        "@wordpress/icons": "^11.7.0",
+        "@wordpress/is-shallow-equal": "^5.40.0",
+        "@wordpress/keycodes": "^4.40.0",
+        "@wordpress/primitives": "^4.40.0",
+        "@wordpress/private-apis": "^1.40.0",
+        "@wordpress/rich-text": "^7.40.0",
+        "@wordpress/warning": "^3.40.0",
+        "change-case": "^4.1.2",
+        "clsx": "^2.1.1",
+        "colord": "^2.7.0",
+        "csstype": "^3.2.3",
+        "date-fns": "^3.6.0",
+        "deepmerge": "^4.3.0",
+        "fast-deep-equal": "^3.1.3",
+        "framer-motion": "^11.15.0",
+        "gradient-parser": "1.1.1",
+        "highlight-words-core": "^1.2.2",
+        "is-plain-object": "^5.0.0",
+        "memize": "^2.1.0",
+        "path-to-regexp": "^6.2.1",
+        "re-resizable": "^6.4.0",
+        "react-colorful": "^5.6.1",
+        "react-day-picker": "^9.7.0",
+        "remove-accents": "^0.5.0",
+        "uuid": "^9.0.1"
       },
       "engines": {
         "node": ">=18.12.0",
@@ -9209,12 +9756,12 @@
       }
     },
     "node_modules/@wordpress/primitives": {
-      "version": "4.37.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/primitives/-/primitives-4.37.0.tgz",
-      "integrity": "sha512-iPpiS1tu1U5cXxVW6CQ45rqdnIc4Ev5FGyicuuaru0wboC+d2CwoNHxPFDOOpGL16yp8OfSDA13vQY3MJHw7QA==",
+      "version": "4.40.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/primitives/-/primitives-4.40.0.tgz",
+      "integrity": "sha512-0gOw3n3kSUsAPo91xNDS9J4GGTrNXU90XmuWn7mNfXAl5uRAMRnxgkfL+pwd0ng0rmdPtjPqrJpljnP2oy3K2w==",
       "license": "GPL-2.0-or-later",
       "dependencies": {
-        "@wordpress/element": "^6.37.0",
+        "@wordpress/element": "^6.40.0",
         "clsx": "^2.1.1"
       },
       "engines": {
@@ -9226,9 +9773,9 @@
       }
     },
     "node_modules/@wordpress/priority-queue": {
-      "version": "3.37.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/priority-queue/-/priority-queue-3.37.0.tgz",
-      "integrity": "sha512-9psU2Sb498WvZNpZkXS0m7JlFdOAp4Ohcj1BfRDDITyWH1xkRhjbp91sPsZGYtaJuDTxa8QEMyb2SSNCqcsRbQ==",
+      "version": "3.40.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/priority-queue/-/priority-queue-3.40.0.tgz",
+      "integrity": "sha512-85km9+I7RWi7P73BU/yom41gpdu0watdQ1GscQhQBel6BjHOXO5qWG6P9i3sEH47bz7EyO248l4LC/h8oHqpfQ==",
       "license": "GPL-2.0-or-later",
       "dependencies": {
         "requestidlecallback": "^0.3.0"
@@ -9239,9 +9786,9 @@
       }
     },
     "node_modules/@wordpress/private-apis": {
-      "version": "1.37.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/private-apis/-/private-apis-1.37.0.tgz",
-      "integrity": "sha512-BR5GEHontWnza1tfBm2aX6/GjCZ1xZRrRNN1P0oj9xuvtut3YzCr//pZuyQ+P5maByDthUZjNrvN3UEF1iucbA==",
+      "version": "1.40.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/private-apis/-/private-apis-1.40.0.tgz",
+      "integrity": "sha512-68cwZKVq8Xy8GBzKoDRuV4b3pQ4nJFItY689HXp+poc0XXrnAeC4ZhjeSgS1qGRpFo6RVvLjjcaZsN2OrSSMvQ==",
       "license": "GPL-2.0-or-later",
       "engines": {
         "node": ">=18.12.0",
@@ -9249,9 +9796,9 @@
       }
     },
     "node_modules/@wordpress/redux-routine": {
-      "version": "5.37.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/redux-routine/-/redux-routine-5.37.0.tgz",
-      "integrity": "sha512-gavsOxTobcOquwl9Kpra0qR30H0vQPK1Rw+K7GDK9bNyJ+/9t4Jio0F6uVN3uQg48h/HomgRX86KCrTET9ntNA==",
+      "version": "5.40.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/redux-routine/-/redux-routine-5.40.0.tgz",
+      "integrity": "sha512-V+c1yCBl4i7qvRsWtQpGevbFCGtrRlzDe++4bwnrYJUiu79wbSXWRrmiSFr/EQie2KNM680t2MeFcfO7nsDVoA==",
       "license": "GPL-2.0-or-later",
       "dependencies": {
         "is-plain-object": "^5.0.0",
@@ -9295,19 +9842,21 @@
       }
     },
     "node_modules/@wordpress/rich-text": {
-      "version": "7.37.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/rich-text/-/rich-text-7.37.0.tgz",
-      "integrity": "sha512-uvLLVg77F4meoMMYjtdYcvo4eQxj3mKH8f9dKnkCrOyKOKNCdV5wHDUYWrySkgrAyoBJjTm8hZKK/U3adlPgEg==",
+      "version": "7.40.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/rich-text/-/rich-text-7.40.0.tgz",
+      "integrity": "sha512-eHImTvzPEg4GWAuzcagyc2tArc6neA2sbqvybpd5JzhEpgv/Q0zcKwLfUKI05kYaaPI/Rg5WXgeXDxjGYpq5hA==",
       "license": "GPL-2.0-or-later",
       "dependencies": {
-        "@wordpress/a11y": "^4.37.0",
-        "@wordpress/compose": "^7.37.0",
-        "@wordpress/data": "^10.37.0",
-        "@wordpress/deprecated": "^4.37.0",
-        "@wordpress/element": "^6.37.0",
-        "@wordpress/escape-html": "^3.37.0",
-        "@wordpress/i18n": "^6.10.0",
-        "@wordpress/keycodes": "^4.37.0",
+        "@wordpress/a11y": "^4.40.0",
+        "@wordpress/compose": "^7.40.0",
+        "@wordpress/data": "^10.40.0",
+        "@wordpress/deprecated": "^4.40.0",
+        "@wordpress/dom": "^4.40.0",
+        "@wordpress/element": "^6.40.0",
+        "@wordpress/escape-html": "^3.40.0",
+        "@wordpress/i18n": "^6.13.0",
+        "@wordpress/keycodes": "^4.40.0",
+        "@wordpress/private-apis": "^1.40.0",
         "colord": "2.9.3",
         "memize": "^2.1.0"
       },
@@ -9470,9 +10019,9 @@
       }
     },
     "node_modules/@wordpress/shortcode": {
-      "version": "4.37.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/shortcode/-/shortcode-4.37.0.tgz",
-      "integrity": "sha512-zLD0bQP5u9eGoJPD4tyn02vqTmSGX0OSZbomUkhv1uAyHkfYSqddrxC/uURNDm7tPl6u3ovB7sVnt0sPJH+ljg==",
+      "version": "4.40.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/shortcode/-/shortcode-4.40.0.tgz",
+      "integrity": "sha512-Cf5aE15kflXL1JV/twK3awjhfrYe0opZbaNS/PtAgDVWnI6TPXfEwwaOXBy+Y6+rAVWV6YTYnv7CNPvGVlZ1YQ==",
       "license": "GPL-2.0-or-later",
       "dependencies": {
         "memize": "^2.0.1"
@@ -9483,9 +10032,9 @@
       }
     },
     "node_modules/@wordpress/style-engine": {
-      "version": "2.37.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/style-engine/-/style-engine-2.37.0.tgz",
-      "integrity": "sha512-2utcjtcQB/WeiXVco0IkZGRMw7UXiOJZpzY3HiGRypRe2J/w2AC1dFMxE45K+lKXiEB6RahYc5HQmRWq0/i+vg==",
+      "version": "2.40.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/style-engine/-/style-engine-2.40.0.tgz",
+      "integrity": "sha512-/xV3VjWo4sq3YR6T/Xo/6DCqILWzD8otzz2xVFAB9kKVfD8fknblkIs5c9Nuv39ZDIqQFJ91YF7Bu6Zw6K2mhg==",
       "license": "GPL-2.0-or-later",
       "dependencies": {
         "change-case": "^4.1.2"
@@ -9537,23 +10086,76 @@
         "npm": ">=8.19.2"
       }
     },
+    "node_modules/@wordpress/theme": {
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/theme/-/theme-0.7.0.tgz",
+      "integrity": "sha512-ULwLCSKYraIsv83bVH+Hm5pGFen6/0/8xOXQwxMdxeU+8kSm0cTKlpQPNvJGCmAeQb2OgFcowB/8wrUdyqW8UQ==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "@wordpress/element": "^6.40.0",
+        "@wordpress/private-apis": "^1.40.0",
+        "colorjs.io": "^0.6.0",
+        "memize": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=18.12.0",
+        "npm": ">=8.19.2"
+      },
+      "peerDependencies": {
+        "react": "^18.0.0",
+        "react-dom": "^18.0.0",
+        "stylelint": "^16.8.2"
+      },
+      "peerDependenciesMeta": {
+        "stylelint": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@wordpress/token-list": {
-      "version": "3.37.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/token-list/-/token-list-3.37.0.tgz",
-      "integrity": "sha512-PHpuRoBC4kgUzJe7aNk/uYGwff5HMsIAKLlVOQ5K9Uw3BJipk56HupsGmXxQ5bKMZetlsOfUHU5dZF3SPZAL5g==",
+      "version": "3.40.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/token-list/-/token-list-3.40.0.tgz",
+      "integrity": "sha512-J9HXmpv0zWgRS8oawSLXaANstZ29pb353rjOYH3RFhawtJd3Z4r6alLy4rLXGEA6CElIACF2PiPCQj+y/iKI+g==",
       "license": "GPL-2.0-or-later",
       "engines": {
         "node": ">=18.12.0",
         "npm": ">=8.19.2"
       }
     },
-    "node_modules/@wordpress/undo-manager": {
-      "version": "1.37.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/undo-manager/-/undo-manager-1.37.0.tgz",
-      "integrity": "sha512-grx0GdEHMgIBj8RHym+FcK/hB4wksQ/ErStFFRCIDhew1i5wAF/boNkxBoGgI42yO5ofSAolcTlGgRCpwTzG5g==",
+    "node_modules/@wordpress/ui": {
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/ui/-/ui-0.7.0.tgz",
+      "integrity": "sha512-StYTQyO66FS71YfTIqYfiuk5C67yeUgINGuql+qSbkT+jdZM//XQmKm1Ffw6+EeWo92LMkZylogXX5NxxSU9rA==",
       "license": "GPL-2.0-or-later",
       "dependencies": {
-        "@wordpress/is-shallow-equal": "^5.37.0"
+        "@base-ui/react": "^1.0.0",
+        "@wordpress/a11y": "^4.40.0",
+        "@wordpress/compose": "^7.40.0",
+        "@wordpress/element": "^6.40.0",
+        "@wordpress/i18n": "^6.13.0",
+        "@wordpress/icons": "^11.7.0",
+        "@wordpress/keycodes": "^4.40.0",
+        "@wordpress/primitives": "^4.40.0",
+        "@wordpress/private-apis": "^1.40.0",
+        "@wordpress/theme": "^0.7.0",
+        "clsx": "^2.1.1"
+      },
+      "engines": {
+        "node": ">=20.10.0",
+        "npm": ">=10.2.3"
+      },
+      "peerDependencies": {
+        "react": "^18.0.0",
+        "react-dom": "^18.0.0"
+      }
+    },
+    "node_modules/@wordpress/undo-manager": {
+      "version": "1.40.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/undo-manager/-/undo-manager-1.40.0.tgz",
+      "integrity": "sha512-QvhHke/bVaOSPeaV5mNvsuIQpc2dJFDhXZ7gUnpuzyuNHh74Xk6Ar0vvYcfXiALst4ejKqWCoKOBi7ve1h2ppg==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "@wordpress/is-shallow-equal": "^5.40.0"
       },
       "engines": {
         "node": ">=18.12.0",
@@ -9561,20 +10163,21 @@
       }
     },
     "node_modules/@wordpress/upload-media": {
-      "version": "0.22.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/upload-media/-/upload-media-0.22.0.tgz",
-      "integrity": "sha512-IQ5/FLmCZm0n/DotF4ZfiYX6pQG8zqVVTfLP/MCIdIKuFHqFs0Z1CAE20qnPDC7kRH+GaGmIIKIYOS0d0rIIdA==",
+      "version": "0.25.1",
+      "resolved": "https://registry.npmjs.org/@wordpress/upload-media/-/upload-media-0.25.1.tgz",
+      "integrity": "sha512-OGr1WMJDeTsQnjZ9RHJ/GGBaUAwdqTIQt/NjABEA3EdQdWXhxzquvfOviV2vQiX3gCrPdHYYf0w9L1i1hiM/+Q==",
       "license": "GPL-2.0-or-later",
       "dependencies": {
-        "@wordpress/api-fetch": "^7.37.0",
-        "@wordpress/blob": "^4.37.0",
-        "@wordpress/compose": "^7.37.0",
-        "@wordpress/data": "^10.37.0",
-        "@wordpress/element": "^6.37.0",
-        "@wordpress/i18n": "^6.10.0",
-        "@wordpress/preferences": "^4.37.0",
-        "@wordpress/private-apis": "^1.37.0",
-        "@wordpress/url": "^4.37.0",
+        "@wordpress/api-fetch": "^7.40.0",
+        "@wordpress/blob": "^4.40.0",
+        "@wordpress/compose": "^7.40.0",
+        "@wordpress/data": "^10.40.0",
+        "@wordpress/element": "^6.40.0",
+        "@wordpress/i18n": "^6.13.0",
+        "@wordpress/preferences": "^4.40.0",
+        "@wordpress/private-apis": "^1.40.0",
+        "@wordpress/url": "^4.40.0",
+        "@wordpress/vips": "^1.0.0",
         "uuid": "^9.0.1"
       },
       "engines": {
@@ -9587,9 +10190,9 @@
       }
     },
     "node_modules/@wordpress/url": {
-      "version": "4.37.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/url/-/url-4.37.0.tgz",
-      "integrity": "sha512-8ofI1OzPON9twQIPczG5WfAtef5hhfZY+FB6cPmwDT5BftQGGO/+v0cHge7pgrRQftSzj4iQ+fQXIdEpIFacgw==",
+      "version": "4.40.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/url/-/url-4.40.0.tgz",
+      "integrity": "sha512-DVAJlW7bdocKfQp8G7tS73vnobAC8TBbIHHdxeLQKwzT8mOkG4W/rpzN2KTxkiJKFXUu5in4F8a6T+Cy/Lt1eQ==",
       "license": "GPL-2.0-or-later",
       "dependencies": {
         "remove-accents": "^0.5.0"
@@ -9617,10 +10220,24 @@
         "react": "^18.0.0"
       }
     },
+    "node_modules/@wordpress/vips": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/vips/-/vips-1.0.0.tgz",
+      "integrity": "sha512-YdSpJ3Gl/LBzLwtMG6mZJkJ5lzotnx+iOzI0emDrTiw8yuN7LWDtj2sx2FAE5Me0dE0dQC5nmm2OQUZVab5PGQ==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "@wordpress/worker-threads": "^1.0.0",
+        "wasm-vips": "^0.0.16"
+      },
+      "engines": {
+        "node": ">=18.12.0",
+        "npm": ">=8.19.2"
+      }
+    },
     "node_modules/@wordpress/warning": {
-      "version": "3.37.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/warning/-/warning-3.37.0.tgz",
-      "integrity": "sha512-oXWyKiYJIa9SuPRNEJiOWn2Qk0RzfxOsDqXcus1OL44swCRtSM+ypm16CJpRhZpMUcsJ6d23PBxTC97C/iiJpQ==",
+      "version": "3.40.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/warning/-/warning-3.40.0.tgz",
+      "integrity": "sha512-0l3OFa1Z+UdhWRRHX9JWWKofo7Lbi2MqOFzzzn0MC26HOyfieQycjLVLNVNXaaodIKUhap6uDQq+JXbbHm881A==",
       "license": "GPL-2.0-or-later",
       "engines": {
         "node": ">=18.12.0",
@@ -9657,10 +10274,23 @@
       }
     },
     "node_modules/@wordpress/wordcount": {
-      "version": "4.37.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/wordcount/-/wordcount-4.37.0.tgz",
-      "integrity": "sha512-Uyl9aR4Tpr/AVoTcqQjkvGE8FE1jXOOooUwcEWCxxe4OLyyKDBs/uJJ2afXzgxc/gNI/QGHArdOA0UArywcnng==",
+      "version": "4.40.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/wordcount/-/wordcount-4.40.0.tgz",
+      "integrity": "sha512-pVL1CURIYNIc0/9l1YncwYvRwm1JoQ2RUy+++3d9oTX7LfAQwbx1IvJEH2S8GpV9/4NrnorRnYKGw8tzxCBtkQ==",
       "license": "GPL-2.0-or-later",
+      "engines": {
+        "node": ">=18.12.0",
+        "npm": ">=8.19.2"
+      }
+    },
+    "node_modules/@wordpress/worker-threads": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/worker-threads/-/worker-threads-1.0.0.tgz",
+      "integrity": "sha512-q/dJ9EQMyA+QQPmQ3oiboLUFn/tT1+B9oPDnmcoWem+dov2bfFKp2NJw1+CBKnA4Q8VBSpPfM2WLmrgM3n/1gw==",
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "comctx": "^1.4.3"
+      },
       "engines": {
         "node": ">=18.12.0",
         "npm": ">=8.19.2"
@@ -9946,7 +10576,7 @@
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
       "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -9956,7 +10586,7 @@
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
       "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "color-convert": "^2.0.1"
@@ -10105,7 +10735,7 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/array-union/-/array-union-2.1.0.tgz",
       "integrity": "sha512-HGyxoOTYUyCM6stUe6EJgnd4EoewAI7zMdfqO+kGjnlZmBDz/cR5pf8r/cR4Wq60sL/p0IkcjUEEPwS3GFrIyw==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -10265,7 +10895,7 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/astral-regex/-/astral-regex-2.0.0.tgz",
       "integrity": "sha512-Z7tMw1ytTXt5jqMcOP+OQteU1VuNK9Y02uuJtKQ1Sv69jXQKKg5cibLwGJow8yzZP+eAc18EmLGPal0bp36rvQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -10864,7 +11494,7 @@
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.3.tgz",
       "integrity": "sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "fill-range": "^7.1.1"
@@ -10985,7 +11615,7 @@
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/cacheable/-/cacheable-2.3.1.tgz",
       "integrity": "sha512-yr+FSHWn1ZUou5LkULX/S+jhfgfnLbuKQjE40tyEd4fxGZVMbBL5ifno0J0OauykS8UiCSgHi+DV/YD+rjFxFg==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@cacheable/memory": "^2.0.6",
@@ -11028,7 +11658,7 @@
       "version": "5.5.5",
       "resolved": "https://registry.npmjs.org/keyv/-/keyv-5.5.5.tgz",
       "integrity": "sha512-FA5LmZVF1VziNc0bIdCSA1IoSVnDCqE8HJIZZv2/W8YmoAM50+tnUgJR/gQZwEeIMleuIOnRnHA/UaZRNeV4iQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@keyv/serialize": "^1.1.1"
@@ -11562,7 +12192,7 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
       "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "color-name": "~1.1.4"
@@ -11575,7 +12205,7 @@
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/colord": {
@@ -11590,6 +12220,16 @@
       "integrity": "sha512-IfEDxwoWIjkeXL1eXcDiow4UbKjhLdq6/EuSVR9GMN7KVH3r9gQ83e73hsz1Nd1T3ijd5xv1wcWRYO+D6kCI2w==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/colorjs.io": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/colorjs.io/-/colorjs.io-0.6.1.tgz",
+      "integrity": "sha512-8lyR2wHzuIykCpqHKgluGsqQi5iDm3/a2IgP2GBZrasn2sBRkE4NOGsglZxWLs/jZQoNkmA/KM/8NV16rLUdBg==",
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/color"
+      }
     },
     "node_modules/colors": {
       "version": "1.1.2",
@@ -11613,6 +12253,12 @@
       "engines": {
         "node": ">= 0.8"
       }
+    },
+    "node_modules/comctx": {
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/comctx/-/comctx-1.6.1.tgz",
+      "integrity": "sha512-ZMRGAYASYRdVfEoB7oxH8Nqu5Ay8I+YvAsQni+td0pYV9eww/PrtSFVyvc2JkNQyHXGDknCB4wJfxFYP6fuqZg==",
+      "license": "MIT"
     },
     "node_modules/commander": {
       "version": "12.1.0",
@@ -12042,7 +12688,7 @@
       "version": "3.2.3",
       "resolved": "https://registry.npmjs.org/css-functions-list/-/css-functions-list-3.2.3.tgz",
       "integrity": "sha512-IQOkD3hbR5KrN93MtcYuad6YPuTSUhntLHDuLEbFWE+ff2/XSZNdZG+LcbbIW5AXKg/WFIfYItIzVoHngHXZzA==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">=12 || >=16"
@@ -12118,7 +12764,7 @@
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/css-tree/-/css-tree-3.1.0.tgz",
       "integrity": "sha512-0eW44TGN5SQXU1mWSkKwFstI/22X2bG1nYzZTYMAWjylYURhse752YgbE4Cx46AC+bAvI+/dYTPRk1LqSUnu6w==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "mdn-data": "2.12.2",
@@ -12145,7 +12791,7 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/cssesc/-/cssesc-3.0.0.tgz",
       "integrity": "sha512-/Tb/JcjK111nNScGob5MNtsntNM1aCNUDipB/TkwZFhyDrrE47SOx/18wF2bbjgc3ZzCSKW1T5nt5EbFoAz/Vg==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "bin": {
         "cssesc": "bin/cssesc"
@@ -12768,7 +13414,7 @@
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/dir-glob/-/dir-glob-3.0.1.tgz",
       "integrity": "sha512-WkrWp9GR4KXfKGYzOLmTuGVi1UWFfws377n9cc55/tb6DuqyF6pcQ5AbiHEshaDpY9v6oaSr2XCDidGmMwdzIA==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "path-type": "^4.0.0"
@@ -13073,7 +13719,7 @@
       "version": "2.2.1",
       "resolved": "https://registry.npmjs.org/env-paths/-/env-paths-2.2.1.tgz",
       "integrity": "sha512-+h1lkLKhZMTYjog1VEpJNG7NZJWcuc2DDk/qsqSTRRCOXiLjeQ1d1/udrUGhqMxUgAlwKNZ0cf2uqan5GLuS2A==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">=6"
@@ -14550,7 +15196,7 @@
       "version": "3.3.3",
       "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.3.3.tgz",
       "integrity": "sha512-7MptL8U0cqcFdzIzwOTHoilX9x5BrNqye7Z/LuC7kCMRio1EMSyqRK3BEAUD7sXRq4iT4AzTVuZdhgQ2TCvYLg==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@nodelib/fs.stat": "^2.0.2",
@@ -14567,7 +15213,7 @@
       "version": "5.1.2",
       "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
       "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
-      "dev": true,
+      "devOptional": true,
       "license": "ISC",
       "dependencies": {
         "is-glob": "^4.0.1"
@@ -14594,7 +15240,7 @@
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.0.tgz",
       "integrity": "sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==",
-      "dev": true,
+      "devOptional": true,
       "funding": [
         {
           "type": "github",
@@ -14611,7 +15257,7 @@
       "version": "1.0.16",
       "resolved": "https://registry.npmjs.org/fastest-levenshtein/-/fastest-levenshtein-1.0.16.tgz",
       "integrity": "sha512-eRnCtTTtGZFpQCwhJiUOuxPQWRXVKYDn0b2PeHfXL6/Zi53SLAzAHfVhVWK2AryC/WH05kGfxhFIPvTF0SXQzg==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">= 4.9.1"
@@ -14621,7 +15267,7 @@
       "version": "1.20.1",
       "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.20.1.tgz",
       "integrity": "sha512-GGToxJ/w1x32s/D2EKND7kTil4n8OVk/9mycTc4VDza13lOvpUZTGX3mFSCtV9ksdGBVzvsyAVLM6mHFThxXxw==",
-      "dev": true,
+      "devOptional": true,
       "license": "ISC",
       "dependencies": {
         "reusify": "^1.0.4"
@@ -14705,7 +15351,7 @@
       "version": "7.1.1",
       "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.1.1.tgz",
       "integrity": "sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "to-regex-range": "^5.0.1"
@@ -14997,7 +15643,7 @@
       "version": "3.3.3",
       "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.3.3.tgz",
       "integrity": "sha512-GX+ysw4PBCz0PzosHDepZGANEuFCMLrnRTiEy9McGjmkCQYwRq4A/X786G/fjM/+OjsWSU1ZrY5qyARZmO/uwg==",
-      "dev": true,
+      "devOptional": true,
       "license": "ISC"
     },
     "node_modules/follow-redirects": {
@@ -15607,7 +16253,7 @@
       "version": "11.1.0",
       "resolved": "https://registry.npmjs.org/globby/-/globby-11.1.0.tgz",
       "integrity": "sha512-jhIXaOzy1sb8IyocaruWSn1TjmnBVs8Ayhcy83rmxNJ8q2uWKCAj3CnJY+KpGSXCueAPc0i05kVvVKtP1t9S3g==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "array-union": "^2.1.0",
@@ -15628,7 +16274,7 @@
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/globjoin/-/globjoin-0.1.4.tgz",
       "integrity": "sha512-xYfnw62CKG8nLkZBfWbhWwDw02CHty86jfPcc2cr3ZfeuK9ysoVPPEUxf21bAD/rWAgk52SuBrLJlefNy8mvFg==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/good-listener": {
@@ -15973,7 +16619,7 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
       "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -16041,7 +16687,7 @@
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/hashery/-/hashery-1.4.0.tgz",
       "integrity": "sha512-Wn2i1In6XFxl8Az55kkgnFRiAlIAushzh26PTjL2AKtQcEfXrcLa7Hn5QOWGZEf3LU057P9TwwZjFyxfS1VuvQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "hookified": "^1.14.0"
@@ -16128,7 +16774,7 @@
       "version": "1.15.0",
       "resolved": "https://registry.npmjs.org/hookified/-/hookified-1.15.0.tgz",
       "integrity": "sha512-51w+ZZGt7Zw5q7rM3nC4t3aLn/xvKDETsXqMczndvwyVQhAHfUmUuFBRFcos8Iyebtk7OAE9dL26wFNzZVVOkw==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/hosted-git-info": {
@@ -16224,7 +16870,7 @@
       "version": "3.3.1",
       "resolved": "https://registry.npmjs.org/html-tags/-/html-tags-3.3.1.tgz",
       "integrity": "sha512-ztqyC3kLto0e9WbNp0aeP+M3kTt+nbaIveGmUxAtZa+8iFgKLUOD4YKM5j+f3QD89bra7UeumolZHKuOXnTmeQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -16431,7 +17077,7 @@
       "version": "5.3.2",
       "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.3.2.tgz",
       "integrity": "sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">= 4"
@@ -16569,7 +17215,7 @@
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
       "integrity": "sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.8.19"
@@ -16607,7 +17253,7 @@
       "version": "1.3.8",
       "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.8.tgz",
       "integrity": "sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==",
-      "dev": true,
+      "devOptional": true,
       "license": "ISC"
     },
     "node_modules/internal-slot": {
@@ -16918,7 +17564,7 @@
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
       "integrity": "sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
@@ -16944,7 +17590,7 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
       "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -16984,7 +17630,7 @@
       "version": "4.0.3",
       "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
       "integrity": "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "is-extglob": "^2.1.1"
@@ -17033,7 +17679,7 @@
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
       "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.12.0"
@@ -17341,7 +17987,7 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
       "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
-      "dev": true,
+      "devOptional": true,
       "license": "ISC"
     },
     "node_modules/isobject": {
@@ -18535,7 +19181,7 @@
       "version": "0.37.0",
       "resolved": "https://registry.npmjs.org/known-css-properties/-/known-css-properties-0.37.0.tgz",
       "integrity": "sha512-JCDrsP4Z1Sb9JwG0aJ8Eo2r7k4Ou5MwmThS/6lcIe1ICyb7UBJKGRIUUdqc2ASdE/42lgz6zFUnzAIhtXnBVrQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/language-subtag-registry": {
@@ -19073,7 +19719,7 @@
       "version": "4.4.2",
       "resolved": "https://registry.npmjs.org/lodash.truncate/-/lodash.truncate-4.4.2.tgz",
       "integrity": "sha512-jttmRe7bRse52OsWIMDLaXxWqRAmtIUccAQ3garviCqJjafXOfNMO0yMfNpdD6zbGaTU0P5Nz7e7gAT6cKmJRw==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/lodash.uniq": {
@@ -19453,7 +20099,7 @@
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/mathml-tag-names/-/mathml-tag-names-2.1.3.tgz",
       "integrity": "sha512-APMBEanjybaPzUrfqU0IMU5I0AswKMH7k8OTLs0vvV4KZpExkTkY87nR/zpbuTPj+gARop7aGUbl11pnDfW6xg==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "funding": {
         "type": "github",
@@ -19464,7 +20110,7 @@
       "version": "2.12.2",
       "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.12.2.tgz",
       "integrity": "sha512-IEn+pegP1aManZuckezWCO+XZQDplx1366JoVhTpMpBB1sPey/SbveZQUosKiKiGYjg1wH4pMlNgXbCiYgihQA==",
-      "dev": true,
+      "devOptional": true,
       "license": "CC0-1.0"
     },
     "node_modules/mdurl": {
@@ -19589,7 +20235,7 @@
       "version": "1.4.1",
       "resolved": "https://registry.npmjs.org/merge2/-/merge2-1.4.1.tgz",
       "integrity": "sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">= 8"
@@ -19616,7 +20262,7 @@
       "version": "4.0.8",
       "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.8.tgz",
       "integrity": "sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "braces": "^3.0.3",
@@ -20182,7 +20828,7 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
       "integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
@@ -21241,7 +21887,7 @@
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
       "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">=8.6"
@@ -22071,14 +22717,14 @@
       "version": "0.1.6",
       "resolved": "https://registry.npmjs.org/postcss-resolve-nested-selector/-/postcss-resolve-nested-selector-0.1.6.tgz",
       "integrity": "sha512-0sglIs9Wmkzbr8lQwEyIzlDOOC9bGmfVKcJTaxv3vMmd3uo4o4DerC3En0bnmgceeql9BfC8hRkp7cg0fjdVqw==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/postcss-safe-parser": {
       "version": "7.0.1",
       "resolved": "https://registry.npmjs.org/postcss-safe-parser/-/postcss-safe-parser-7.0.1.tgz",
       "integrity": "sha512-0AioNCJZ2DPYz5ABT6bddIqlhgwhpHZ/l65YAYo0BCIn0xiDpsnTHz0gnoTGk0OXZW0JRs+cDwL8u/teRdz+8A==",
-      "dev": true,
+      "devOptional": true,
       "funding": [
         {
           "type": "opencollective",
@@ -22490,7 +23136,7 @@
       "version": "0.5.3",
       "resolved": "https://registry.npmjs.org/qified/-/qified-0.5.3.tgz",
       "integrity": "sha512-kXuQdQTB6oN3KhI6V4acnBSZx8D2I4xzZvn9+wFLLFCoBNQY/sFnCW6c43OL7pOQ2HvGV4lnWIXNmgfp7cTWhQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "hookified": "^1.13.0"
@@ -23083,7 +23729,7 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
       "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
@@ -23125,6 +23771,12 @@
       "resolved": "https://registry.npmjs.org/requires-port/-/requires-port-1.0.0.tgz",
       "integrity": "sha512-KigOCHcocU3XODJxsu8i/j8T9tzT4adHiecwORRQ0ZZFcp7ahwXuRU1m+yuO90C5ZUyGeGfocHDI14M3L3yDAQ==",
       "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/reselect": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/reselect/-/reselect-5.1.1.tgz",
+      "integrity": "sha512-K/BG6eIky/SBpzfHZv/dd+9JBFiS4SWV7FIujVyJRux6e45+73RaUHXLmIR1f7WOMaQ0U1km6qwklRQxpJJY0w==",
       "license": "MIT"
     },
     "node_modules/resolve": {
@@ -23208,7 +23860,7 @@
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-5.0.0.tgz",
       "integrity": "sha512-qYg9KP24dD5qka9J47d0aVky0N+b4fTU89LN9iDnjB5waksiC49rvMB0PrUJQGoTmH50XPiqOvAjDfaijGxYZw==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -23282,7 +23934,7 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/reusify/-/reusify-1.1.0.tgz",
       "integrity": "sha512-g6QUff04oZpHs0eG5p83rFLhHeV00ug/Yf9nZM6fLeUrPguBTkTQOdpAWWspMh55TZfVQDPaN3NQJfbVRAxdIw==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "engines": {
         "iojs": ">=1.0.0",
@@ -23454,7 +24106,7 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/run-parallel/-/run-parallel-1.2.0.tgz",
       "integrity": "sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==",
-      "dev": true,
+      "devOptional": true,
       "funding": [
         {
           "type": "github",
@@ -24405,7 +25057,7 @@
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
       "integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
-      "dev": true,
+      "devOptional": true,
       "license": "ISC",
       "engines": {
         "node": ">=14"
@@ -24505,7 +25157,7 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/slash/-/slash-3.0.0.tgz",
       "integrity": "sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -24515,7 +25167,7 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-4.0.0.tgz",
       "integrity": "sha512-qMCMfhY040cVHT43K9BFygqYbUPFZKHOg7K73mtTWJRb8pyP3fzf4Ixd5SzdEJQ6MRUg/WBnOLxghZtKKurENQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "ansi-styles": "^4.0.0",
@@ -24915,7 +25567,7 @@
       "version": "4.2.3",
       "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
       "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "emoji-regex": "^8.0.0",
@@ -24953,7 +25605,7 @@
       "version": "8.0.0",
       "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
       "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/string.prototype.includes": {
@@ -25073,7 +25725,7 @@
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
       "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "ansi-regex": "^5.0.1"
@@ -25210,7 +25862,7 @@
       "version": "16.26.1",
       "resolved": "https://registry.npmjs.org/stylelint/-/stylelint-16.26.1.tgz",
       "integrity": "sha512-v20V59/crfc8sVTAtge0mdafI3AdnzQ2KsWe6v523L4OA1bJO02S7MO2oyXDCS6iWb9ckIPnqAFVItqSBQr7jw==",
-      "dev": true,
+      "devOptional": true,
       "funding": [
         {
           "type": "opencollective",
@@ -25365,7 +26017,7 @@
       "version": "4.0.3",
       "resolved": "https://registry.npmjs.org/@csstools/media-query-list-parser/-/media-query-list-parser-4.0.3.tgz",
       "integrity": "sha512-HAYH7d3TLRHDOUQK4mZKf9k9Ph/m8Akstg66ywKR4SFAigjs3yBiUeZtFxywiTm5moZMAp/5W/ZuFnNXXYLuuQ==",
-      "dev": true,
+      "devOptional": true,
       "funding": [
         {
           "type": "github",
@@ -25389,7 +26041,7 @@
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/@csstools/selector-specificity/-/selector-specificity-5.0.0.tgz",
       "integrity": "sha512-PCqQV3c4CoVm3kdPhyeZ07VmBRdH2EpMFA/pd9OASpOEC3aXNGoqPDAZ80D0cLpMBxnmk0+yNhGsEx31hq7Gtw==",
-      "dev": true,
+      "devOptional": true,
       "funding": [
         {
           "type": "github",
@@ -25412,21 +26064,21 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
       "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
-      "dev": true,
+      "devOptional": true,
       "license": "Python-2.0"
     },
     "node_modules/stylelint/node_modules/balanced-match": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-2.0.0.tgz",
       "integrity": "sha512-1ugUSr8BHXRnK23KfuYS+gVMC3LB8QGH9W1iGtDPsNWoQbgtXSExkBu2aDR4epiGWZOjZsj6lDl/N/AqqTC3UA==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/stylelint/node_modules/cosmiconfig": {
       "version": "9.0.0",
       "resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-9.0.0.tgz",
       "integrity": "sha512-itvL5h8RETACmOTFc4UfIyB2RfEHi71Ax6E/PivVxq9NseKbOWpeyHEOIbmAw1rs8Ak0VursQNww7lf7YtUwzg==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "env-paths": "^2.2.1",
@@ -25453,7 +26105,7 @@
       "version": "11.1.1",
       "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-11.1.1.tgz",
       "integrity": "sha512-TPVFSDE7q91Dlk1xpFLvFllf8r0HyOMOlnWy7Z2HBku5H3KhIeOGInexrIeg2D64DosVB/JXkrrk6N/7Wriq4A==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "flat-cache": "^6.1.19"
@@ -25463,7 +26115,7 @@
       "version": "6.1.19",
       "resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-6.1.19.tgz",
       "integrity": "sha512-l/K33newPTZMTGAnnzaiqSl6NnH7Namh8jBNjrgjprWxGmZUuxx/sJNIRaijOh3n7q7ESbhNZC+pvVZMFdeU4A==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "cacheable": "^2.2.0",
@@ -25475,7 +26127,7 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/global-modules/-/global-modules-2.0.0.tgz",
       "integrity": "sha512-NGbfmJBp9x8IxyJSd1P+otYK8vonoJactOogrVfFRIAEY1ukil8RSKDz2Yo7wh1oihl51l/r6W4epkeKJHqL8A==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "global-prefix": "^3.0.0"
@@ -25488,7 +26140,7 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/global-prefix/-/global-prefix-3.0.0.tgz",
       "integrity": "sha512-awConJSVCHVGND6x3tmMaKcQvwXLhjdkmomy2W+Goaui8YPgYgXJZewhg3fWC+DlfqqQuWg8AwqjGTD2nAPVWg==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "ini": "^1.3.5",
@@ -25503,7 +26155,7 @@
       "version": "7.0.5",
       "resolved": "https://registry.npmjs.org/ignore/-/ignore-7.0.5.tgz",
       "integrity": "sha512-Hs59xBNfUIunMFgWAbGX5cq6893IbWg4KnrjbYwX3tx0ztorVgTDA6B2sxf8ejHJ4wz8BqGUMYlnzNBer5NvGg==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">= 4"
@@ -25513,7 +26165,7 @@
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.1.tgz",
       "integrity": "sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "argparse": "^2.0.1"
@@ -25526,7 +26178,7 @@
       "version": "6.0.3",
       "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.3.tgz",
       "integrity": "sha512-dcS1ul+9tmeD95T+x28/ehLgd9mENa3LsvDTtzm3vyBEO7RPptvAD+t44WVXaUjTBRcrpFeFlC8WCruUR456hw==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
@@ -25536,7 +26188,7 @@
       "version": "13.2.0",
       "resolved": "https://registry.npmjs.org/meow/-/meow-13.2.0.tgz",
       "integrity": "sha512-pxQJQzB6djGPXh08dacEloMFopsOqGVRKFPYvPOt9XDZ1HasbgDZA74CJGreSU4G3Ak7EFJGoiH2auq+yXISgA==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">=18"
@@ -25549,7 +26201,7 @@
       "version": "7.1.1",
       "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-7.1.1.tgz",
       "integrity": "sha512-orRsuYpJVw8LdAwqqLykBj9ecS5/cRHlI5+nvTo8LcCKmzDmqVORXtOIYEEQuL9D4BxtA1lm5isAqzQZCoQ6Eg==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "cssesc": "^3.0.0",
@@ -25563,7 +26215,7 @@
       "version": "1.3.1",
       "resolved": "https://registry.npmjs.org/which/-/which-1.3.1.tgz",
       "integrity": "sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "ISC",
       "dependencies": {
         "isexe": "^2.0.0"
@@ -25576,7 +26228,7 @@
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-5.0.1.tgz",
       "integrity": "sha512-+QU2zd6OTD8XWIJCbffaiQeH9U73qIqafo1x6V1snCWYGJf6cVE0cDR4D8xRzcEnfI21IFrUPzPGtcPf8AC+Rw==",
-      "dev": true,
+      "devOptional": true,
       "license": "ISC",
       "dependencies": {
         "imurmurhash": "^0.1.4",
@@ -25596,7 +26248,7 @@
       "version": "7.2.0",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
       "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "has-flag": "^4.0.0"
@@ -25609,7 +26261,7 @@
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/supports-hyperlinks/-/supports-hyperlinks-3.2.0.tgz",
       "integrity": "sha512-zFObLMyZeEwzAoKCyu1B91U79K2t7ApXuQfo8OuxwXLDgcKxuwM+YvcbIhm6QWqz7mHUH1TVytR1PwVVjEuMig==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "has-flag": "^4.0.0",
@@ -25645,7 +26297,7 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/svg-tags/-/svg-tags-1.0.0.tgz",
       "integrity": "sha512-ovssysQTa+luh7A5Weu3Rta6FJlFBBbInjOh722LIt6klpU2/HtdUbszju/G4devcvk8PGt7FCLv5wftu3THUA==",
-      "dev": true
+      "devOptional": true
     },
     "node_modules/svgo": {
       "version": "3.3.2",
@@ -25727,11 +26379,17 @@
         "url": "https://opencollective.com/synckit"
       }
     },
+    "node_modules/tabbable": {
+      "version": "6.4.0",
+      "resolved": "https://registry.npmjs.org/tabbable/-/tabbable-6.4.0.tgz",
+      "integrity": "sha512-05PUHKSNE8ou2dwIxTngl4EzcnsCDZGJ/iCLtDflR/SHB/ny14rXc+qU5P4mG9JkusiV7EivzY9Mhm55AzAvCg==",
+      "license": "MIT"
+    },
     "node_modules/table": {
       "version": "6.9.0",
       "resolved": "https://registry.npmjs.org/table/-/table-6.9.0.tgz",
       "integrity": "sha512-9kY+CygyYM6j02t5YFHbNz2FN5QmYGv9zAjVp4lCDjlCw7amdckXlEt/bjMhUIfj4ThGRE4gCUH5+yGnNuPo5A==",
-      "dev": true,
+      "devOptional": true,
       "license": "BSD-3-Clause",
       "dependencies": {
         "ajv": "^8.0.1",
@@ -25748,7 +26406,7 @@
       "version": "8.17.1",
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.17.1.tgz",
       "integrity": "sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "fast-deep-equal": "^3.1.3",
@@ -25765,7 +26423,7 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
       "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/tannin": {
@@ -26202,7 +26860,7 @@
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
       "integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "is-number": "^7.0.0"
@@ -26524,7 +27182,7 @@
       "version": "5.9.3",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
-      "dev": true,
+      "devOptional": true,
       "license": "Apache-2.0",
       "peer": true,
       "bin": {
@@ -27037,6 +27695,15 @@
       "license": "Apache-2.0",
       "dependencies": {
         "makeerror": "1.0.12"
+      }
+    },
+    "node_modules/wasm-vips": {
+      "version": "0.0.16",
+      "resolved": "https://registry.npmjs.org/wasm-vips/-/wasm-vips-0.0.16.tgz",
+      "integrity": "sha512-4/bEq8noAFt7DX3VT+Vt5AgNtnnOLwvmrDbduWfiv9AV+VYkbUU4f9Dam9e6khRqPinyClFHCqiwATTTJEiGwA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=16.4.0"
       }
     },
     "node_modules/watchpack": {

--- a/package.json
+++ b/package.json
@@ -48,6 +48,7 @@
     "@wordpress/edit-post": "^8.37.0",
     "@wordpress/editor": "^14.37.0",
     "@wordpress/element": "^6.37.0",
+    "@wordpress/format-library": "^5.37.0",
     "@wordpress/i18n": "^6.10.0",
     "@wordpress/icons": "^11.4.0",
     "@wordpress/rich-text": "^7.37.0"

--- a/src/index.js
+++ b/src/index.js
@@ -10,6 +10,7 @@
 /**
  * WordPress dependencies
  */
+import '@wordpress/format-library';
 import { createRoot, StrictMode } from '@wordpress/element';
 import domReady from '@wordpress/dom-ready';
 


### PR DESCRIPTION
## Summary

Import `@wordpress/format-library` to register standard rich text format types and their keyboard shortcuts. Press This uses `BlockEditorProvider` directly rather than the full `EditorProvider`, which means format-library isn't initialized automatically. Without it, shortcuts like Ctrl+K (link), Ctrl+B (bold), and Ctrl+I (italic) don't work.

- Add `@wordpress/format-library` as a dependency
- Import it in the entry point so it registers format types on load
- Add `docs/keyboard-shortcuts.md` documenting which Gutenberg shortcuts are available in Press This and which aren't

See #81

## Test plan

- [ ] Open Press This and type some text in a paragraph block
- [ ] Ctrl+B / Cmd+B should toggle bold
- [ ] Ctrl+I / Cmd+I should toggle italic
- [ ] Ctrl+K / Cmd+K should open the link popover
- [ ] Ctrl+U / Cmd+U should toggle underline
- [ ] Ctrl+Alt+D / Ctrl+Option+D should toggle strikethrough
- [ ] Ctrl+Alt+X / Ctrl+Option+X should toggle inline code
- [ ] Verify the block toolbar shows formatting buttons (bold, italic, link)