### PR TITLE
Add block transform keyboard shortcuts

### DIFF
--- a/docs/keyboard-shortcuts.md
+++ b/docs/keyboard-shortcuts.md
@@ -1,0 +1,78 @@
+# Keyboard Shortcuts
+
+Press This uses `BlockEditorProvider` directly rather than the full Gutenberg `EditorProvider`. This means not all keyboard shortcuts from the standard WordPress editor are available. This document tracks what's supported and what isn't.
+
+Modifier key conventions: "Primary" is Ctrl on Windows/Linux, Cmd on macOS. "Access" is Ctrl+Alt on Windows/Linux, Ctrl+Option on macOS. "Secondary" is Ctrl+Shift on Windows/Linux, Cmd+Shift on macOS.
+
+## Block Transform Shortcuts
+
+Provided by Press This's `BlockTransformShortcuts` component. These mirror Gutenberg's internal block-library shortcuts with the addition of a quote toggle.
+
+| Shortcut | Action | Status |
+|----------|--------|--------|
+| Access+1 through Access+6 | Transform paragraph/heading to heading level 1-6 | Available |
+| Access+0 | Transform heading to paragraph | Available |
+| Access+7 | Transform heading to paragraph (alias) | Available |
+| Access+Q | Toggle between paragraph and quote | Available |
+
+## Block Editing Shortcuts
+
+Provided by `BlockEditorKeyboardShortcuts` from `@wordpress/block-editor`. These operate on selected blocks.
+
+| Shortcut | Action | Status |
+|----------|--------|--------|
+| Primary+A | Select all text, then all blocks | Available |
+| Primary+C | Copy selected block(s) | Available |
+| Primary+X | Cut selected block(s) | Available |
+| Primary+V | Paste | Available |
+| Primary+Shift+D | Duplicate selected block(s) | Available |
+| Access+Z | Remove selected block(s) | Available |
+| Primary+Alt+V | Paste styles | Available |
+| Primary+Alt+T | Insert block before | Available |
+| Primary+Alt+Y | Insert block after | Available |
+| Secondary+T | Move block up | Available |
+| Secondary+Y | Move block down | Available |
+| Primary+G | Group selected blocks | Available |
+| Primary+Shift+H | Toggle block visibility | Available |
+| Primary+Alt+R | Rename block | Available |
+| Escape | Clear selection / stop editing | Available |
+| Alt+F10 | Focus toolbar | Available |
+| / | Open block inserter (in empty paragraph) | Available |
+
+## Rich Text Format Shortcuts
+
+Provided by `@wordpress/format-library` (see PR #83). These work inside any rich text block (paragraphs, headings, quotes, lists).
+
+| Shortcut | Action | Status |
+|----------|--------|--------|
+| Primary+B | Bold | See [PR #83](https://github.com/WordPress/press-this/pull/83) |
+| Primary+I | Italic | See [PR #83](https://github.com/WordPress/press-this/pull/83) |
+| Primary+K | Insert/edit link | See [PR #83](https://github.com/WordPress/press-this/pull/83) |
+| Primary+Shift+K | Remove link | See [PR #83](https://github.com/WordPress/press-this/pull/83) |
+| Primary+U | Underline | See [PR #83](https://github.com/WordPress/press-this/pull/83) |
+| Access+D | Strikethrough | See [PR #83](https://github.com/WordPress/press-this/pull/83) |
+| Access+X | Inline code | See [PR #83](https://github.com/WordPress/press-this/pull/83) |
+
+## Editor-Level Shortcuts (Not Available)
+
+These shortcuts are registered by `EditorKeyboardShortcuts` in `@wordpress/editor`, which Press This doesn't use. Some are being addressed through alternative implementations.
+
+| Shortcut | Action | Status | Notes |
+|----------|--------|--------|-------|
+| Primary+Z | Undo | Not available | See [#75](https://github.com/WordPress/press-this/issues/75), [PR #78](https://github.com/WordPress/press-this/pull/78) |
+| Primary+Shift+Z | Redo | Not available | See [#75](https://github.com/WordPress/press-this/issues/75), [PR #78](https://github.com/WordPress/press-this/pull/78) |
+| Primary+Y | Redo (Windows/Linux) | Not available | See [#75](https://github.com/WordPress/press-this/issues/75), [PR #78](https://github.com/WordPress/press-this/pull/78) |
+| Primary+S | Save | Not available | |
+| Secondary+M | Toggle code editor | Not available | Not applicable to Press This |
+| Access+O | Toggle list view | Not available | |
+| Primary+Shift+, | Toggle settings panel | Not available | |
+| Primary+Shift+\ | Distraction-free mode | Not available | |
+| Access+H | Show keyboard shortcuts | Not available | |
+
+## Legacy Shortcuts (Not Available)
+
+These shortcuts existed in the classic TinyMCE editor but were never part of the block editor.
+
+| Shortcut | Action | Notes |
+|----------|--------|-------|
+| Ctrl+Alt+Q | Toggle blockquote | Classic editor only. Use Access+Q instead (see Block Transform Shortcuts above). |

--- a/package-lock.json
+++ b/package-lock.json
@@ -23,7 +23,6 @@
         "@wordpress/i18n": "^6.10.0",
         "@wordpress/icons": "^11.4.0",
         "@wordpress/keyboard-shortcuts": "^5.37.0",
-        "@wordpress/keycodes": "^4.37.0",
         "@wordpress/rich-text": "^7.37.0"
       },
       "devDependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -22,6 +22,8 @@
         "@wordpress/element": "^6.37.0",
         "@wordpress/i18n": "^6.10.0",
         "@wordpress/icons": "^11.4.0",
+        "@wordpress/keyboard-shortcuts": "^5.37.0",
+        "@wordpress/keycodes": "^4.37.0",
         "@wordpress/rich-text": "^7.37.0"
       },
       "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -49,6 +49,8 @@
     "@wordpress/editor": "^14.37.0",
     "@wordpress/element": "^6.37.0",
     "@wordpress/i18n": "^6.10.0",
+    "@wordpress/keyboard-shortcuts": "^5.37.0",
+    "@wordpress/keycodes": "^4.37.0",
     "@wordpress/icons": "^11.4.0",
     "@wordpress/rich-text": "^7.37.0"
   },

--- a/package.json
+++ b/package.json
@@ -50,7 +50,6 @@
     "@wordpress/element": "^6.37.0",
     "@wordpress/i18n": "^6.10.0",
     "@wordpress/keyboard-shortcuts": "^5.37.0",
-    "@wordpress/keycodes": "^4.37.0",
     "@wordpress/icons": "^11.4.0",
     "@wordpress/rich-text": "^7.37.0"
   },

--- a/src/components/BlockTransformShortcuts.js
+++ b/src/components/BlockTransformShortcuts.js
@@ -1,0 +1,228 @@
+/**
+ * Block Transform Keyboard Shortcuts
+ *
+ * Registers keyboard shortcuts for transforming blocks between types.
+ * Mirrors the behavior of @wordpress/block-library's internal
+ * BlockKeyboardShortcuts component, which Press This doesn't render
+ * since it uses BlockEditorProvider directly.
+ *
+ * @package
+ */
+
+/**
+ * WordPress dependencies
+ */
+import { useEffect } from '@wordpress/element';
+import { useSelect, useDispatch } from '@wordpress/data';
+import {
+	useShortcut,
+	store as keyboardShortcutsStore,
+} from '@wordpress/keyboard-shortcuts';
+import { __ } from '@wordpress/i18n';
+import { createBlock } from '@wordpress/blocks';
+import { store as blockEditorStore } from '@wordpress/block-editor';
+
+/**
+ * Register all block transform shortcuts and bind their handlers.
+ *
+ * Shortcuts registered:
+ * - Access+1 through Access+6: Transform paragraph/heading to heading level 1-6
+ * - Access+0 (and Access+7 alias): Transform heading back to paragraph
+ * - Access+Q: Toggle between paragraph and quote
+ *
+ * @return {null} This component renders nothing.
+ */
+export default function BlockTransformShortcuts() {
+	const { registerShortcut } = useDispatch( keyboardShortcutsStore );
+	const { replaceBlocks } = useDispatch( blockEditorStore );
+	const {
+		getBlockName,
+		getSelectedBlockClientId,
+		getBlockAttributes,
+		getBlock,
+	} = useSelect( blockEditorStore );
+
+	/**
+	 * Transform the selected block between paragraph and heading.
+	 *
+	 * @param {Event}  event Keyboard event.
+	 * @param {number} level Heading level (1-6), or 0 for paragraph.
+	 */
+	const handleHeadingTransform = ( event, level ) => {
+		event.preventDefault();
+
+		const currentClientId = getSelectedBlockClientId();
+		if ( currentClientId === null ) {
+			return;
+		}
+
+		const blockName = getBlockName( currentClientId );
+		const isParagraph = blockName === 'core/paragraph';
+		const isHeading = blockName === 'core/heading';
+
+		if ( ! isParagraph && ! isHeading ) {
+			return;
+		}
+
+		const attributes = getBlockAttributes( currentClientId );
+
+		// Avoid unnecessary transform to the same type/level.
+		if (
+			( isParagraph && level === 0 ) ||
+			( isHeading && attributes.level === level )
+		) {
+			return;
+		}
+
+		const destinationBlockName =
+			level === 0 ? 'core/paragraph' : 'core/heading';
+
+		const newAttributes = {
+			content: attributes.content,
+		};
+
+		if ( destinationBlockName === 'core/heading' ) {
+			newAttributes.level = level;
+		}
+
+		// Preserve text alignment.
+		const sourceTextAlign =
+			attributes.textAlign || attributes.style?.typography?.textAlign;
+		if ( sourceTextAlign ) {
+			newAttributes.style = {
+				typography: {
+					textAlign: sourceTextAlign,
+				},
+			};
+		}
+
+		replaceBlocks(
+			currentClientId,
+			createBlock( destinationBlockName, newAttributes )
+		);
+	};
+
+	/**
+	 * Toggle the selected block between paragraph and quote.
+	 *
+	 * @param {Event} event Keyboard event.
+	 */
+	const handleQuoteToggle = ( event ) => {
+		event.preventDefault();
+
+		const currentClientId = getSelectedBlockClientId();
+		if ( currentClientId === null ) {
+			return;
+		}
+
+		const blockName = getBlockName( currentClientId );
+
+		if ( blockName === 'core/paragraph' ) {
+			const attributes = getBlockAttributes( currentClientId );
+			// Paragraph -> Quote: wrap content as an inner paragraph block.
+			replaceBlocks(
+				currentClientId,
+				createBlock( 'core/quote', {}, [
+					createBlock( 'core/paragraph', {
+						content: attributes.content,
+					} ),
+				] )
+			);
+		} else if ( blockName === 'core/quote' ) {
+			// Quote -> Paragraph(s): extract inner blocks.
+			// Modern quote blocks use inner blocks for content.
+			const quoteBlock = getBlock( currentClientId );
+			const innerBlocks = quoteBlock?.innerBlocks || [];
+
+			if ( innerBlocks.length > 0 ) {
+				// Replace the quote with its inner blocks directly.
+				const replacementBlocks = innerBlocks.map( ( inner ) =>
+					createBlock( inner.name, { ...inner.attributes } )
+				);
+				replaceBlocks( currentClientId, replacementBlocks );
+			} else {
+				// Fallback for older quote format using value attribute.
+				const attributes = getBlockAttributes( currentClientId );
+				replaceBlocks(
+					currentClientId,
+					createBlock( 'core/paragraph', {
+						content: attributes.value || '',
+					} )
+				);
+			}
+		}
+	};
+
+	// Register shortcut metadata.
+	useEffect( () => {
+		registerShortcut( {
+			name: 'press-this/transform-heading-to-paragraph',
+			category: 'block-library',
+			description: __( 'Transform heading to paragraph.', 'press-this' ),
+			keyCombination: {
+				modifier: 'access',
+				character: '0',
+			},
+			aliases: [
+				{
+					modifier: 'access',
+					character: '7',
+				},
+			],
+		} );
+
+		[ 1, 2, 3, 4, 5, 6 ].forEach( ( level ) => {
+			registerShortcut( {
+				name: `press-this/transform-paragraph-to-heading-${ level }`,
+				category: 'block-library',
+				description: __(
+					'Transform paragraph to heading.',
+					'press-this'
+				),
+				keyCombination: {
+					modifier: 'access',
+					character: `${ level }`,
+				},
+			} );
+		} );
+
+		registerShortcut( {
+			name: 'press-this/transform-quote-toggle',
+			category: 'block-library',
+			description: __(
+				'Toggle between paragraph and quote.',
+				'press-this'
+			),
+			keyCombination: {
+				modifier: 'access',
+				character: 'q',
+			},
+		} );
+	}, [ registerShortcut ] );
+
+	// Bind shortcut handlers.
+	useShortcut( 'press-this/transform-heading-to-paragraph', ( event ) =>
+		handleHeadingTransform( event, 0 )
+	);
+	useShortcut( 'press-this/transform-paragraph-to-heading-1', ( event ) =>
+		handleHeadingTransform( event, 1 )
+	);
+	useShortcut( 'press-this/transform-paragraph-to-heading-2', ( event ) =>
+		handleHeadingTransform( event, 2 )
+	);
+	useShortcut( 'press-this/transform-paragraph-to-heading-3', ( event ) =>
+		handleHeadingTransform( event, 3 )
+	);
+	useShortcut( 'press-this/transform-paragraph-to-heading-4', ( event ) =>
+		handleHeadingTransform( event, 4 )
+	);
+	useShortcut( 'press-this/transform-paragraph-to-heading-5', ( event ) =>
+		handleHeadingTransform( event, 5 )
+	);
+	useShortcut( 'press-this/transform-paragraph-to-heading-6', ( event ) =>
+		handleHeadingTransform( event, 6 )
+	);
+	useShortcut( 'press-this/transform-quote-toggle', handleQuoteToggle );
+
+	return null;
+}

--- a/src/components/BlockTransformShortcuts.js
+++ b/src/components/BlockTransformShortcuts.js
@@ -137,7 +137,7 @@ export default function BlockTransformShortcuts() {
 			if ( innerBlocks.length > 0 ) {
 				// Replace the quote with its inner blocks directly.
 				const replacementBlocks = innerBlocks.map( ( inner ) =>
-					createBlock( inner.name, { ...inner.attributes } )
+					createBlock( inner.name, { ...inner.attributes }, inner.innerBlocks )
 				);
 				replaceBlocks( currentClientId, replacementBlocks );
 			} else {

--- a/src/components/PressThisEditor.js
+++ b/src/components/PressThisEditor.js
@@ -49,6 +49,7 @@ import { registerCoreBlocks } from '@wordpress/block-library';
 /**
  * Internal dependencies
  */
+import BlockTransformShortcuts from './BlockTransformShortcuts';
 import ScrapedMediaPanel from './ScrapedMediaPanel';
 import FeaturedImagePanel from './FeaturedImagePanel';
 
@@ -673,6 +674,7 @@ export default function PressThisEditor( {
 							{ /* Block editor */ }
 							<div className="press-this-editor__content">
 								<BlockEditorKeyboardShortcuts.Register />
+								<BlockTransformShortcuts />
 								<BlockTools>
 									<WritingFlow>
 										<ObserveTyping>

--- a/tests/components/block-transform-shortcuts.test.js
+++ b/tests/components/block-transform-shortcuts.test.js
@@ -1,0 +1,514 @@
+/**
+ * Block Transform Keyboard Shortcuts Tests
+ *
+ * @package press-this
+ */
+
+/**
+ * WordPress dependencies
+ */
+import { useSelect, useDispatch } from '@wordpress/data';
+import { useShortcut } from '@wordpress/keyboard-shortcuts';
+import { createBlock } from '@wordpress/blocks';
+
+/**
+ * Internal dependencies
+ */
+import BlockTransformShortcuts from '../../src/components/BlockTransformShortcuts';
+
+// Store sentinels for routing mock returns.
+const BLOCK_EDITOR_STORE = { name: 'core/block-editor' };
+const KEYBOARD_SHORTCUTS_STORE = { name: 'core/keyboard-shortcuts' };
+
+jest.mock( '@wordpress/block-editor', () => ( {
+	store: BLOCK_EDITOR_STORE,
+} ) );
+
+jest.mock( '@wordpress/keyboard-shortcuts', () => ( {
+	useShortcut: jest.fn(),
+	store: KEYBOARD_SHORTCUTS_STORE,
+} ) );
+
+jest.mock( '@wordpress/data', () => ( {
+	useSelect: jest.fn(),
+	useDispatch: jest.fn(),
+} ) );
+
+jest.mock( '@wordpress/blocks', () => ( {
+	createBlock: jest.fn( ( name, attrs, innerBlocks ) => ( {
+		name,
+		attributes: attrs || {},
+		innerBlocks: innerBlocks || [],
+	} ) ),
+} ) );
+
+jest.mock( '@wordpress/element', () => ( {
+	useEffect: ( fn ) => fn(),
+} ) );
+
+jest.mock( '@wordpress/i18n', () => ( {
+	__: ( text ) => text,
+} ) );
+
+describe( 'BlockTransformShortcuts', () => {
+	let registerShortcut;
+	let replaceBlocks;
+	let getSelectedBlockClientId;
+	let getBlockName;
+	let getBlockAttributes;
+	let getBlock;
+
+	// Captured useShortcut handlers keyed by shortcut name.
+	let shortcutHandlers;
+
+	beforeEach( () => {
+		jest.clearAllMocks();
+
+		registerShortcut = jest.fn();
+		replaceBlocks = jest.fn();
+		getSelectedBlockClientId = jest.fn( () => null );
+		getBlockName = jest.fn();
+		getBlockAttributes = jest.fn( () => ( {} ) );
+		getBlock = jest.fn();
+
+		shortcutHandlers = {};
+
+		useDispatch.mockImplementation( ( store ) => {
+			if ( store === KEYBOARD_SHORTCUTS_STORE ) {
+				return { registerShortcut };
+			}
+			if ( store === BLOCK_EDITOR_STORE ) {
+				return { replaceBlocks };
+			}
+			return {};
+		} );
+
+		useSelect.mockReturnValue( {
+			getSelectedBlockClientId,
+			getBlockName,
+			getBlockAttributes,
+			getBlock,
+		} );
+
+		useShortcut.mockImplementation( ( name, handler ) => {
+			shortcutHandlers[ name ] = handler;
+		} );
+	} );
+
+	function renderComponent() {
+		BlockTransformShortcuts();
+	}
+
+	function fireShortcut( name, event ) {
+		const handler = shortcutHandlers[ name ];
+		expect( handler ).toBeDefined();
+		handler( event || { preventDefault: jest.fn() } );
+	}
+
+	// -------------------------------------------------------------------------
+	// Shortcut registration
+	// -------------------------------------------------------------------------
+
+	describe( 'Shortcut Registration', () => {
+		test( 'registers heading-to-paragraph shortcut with Access+0 and Access+7 alias', () => {
+			renderComponent();
+
+			expect( registerShortcut ).toHaveBeenCalledWith(
+				expect.objectContaining( {
+					name: 'press-this/transform-heading-to-paragraph',
+					keyCombination: { modifier: 'access', character: '0' },
+					aliases: [ { modifier: 'access', character: '7' } ],
+				} )
+			);
+		} );
+
+		test( 'registers heading level 1-6 shortcuts', () => {
+			renderComponent();
+
+			for ( let level = 1; level <= 6; level++ ) {
+				expect( registerShortcut ).toHaveBeenCalledWith(
+					expect.objectContaining( {
+						name: `press-this/transform-paragraph-to-heading-${ level }`,
+						keyCombination: {
+							modifier: 'access',
+							character: `${ level }`,
+						},
+					} )
+				);
+			}
+		} );
+
+		test( 'registers quote toggle shortcut with Access+Q', () => {
+			renderComponent();
+
+			expect( registerShortcut ).toHaveBeenCalledWith(
+				expect.objectContaining( {
+					name: 'press-this/transform-quote-toggle',
+					keyCombination: { modifier: 'access', character: 'q' },
+				} )
+			);
+		} );
+
+		test( 'registers exactly 8 shortcuts total', () => {
+			renderComponent();
+
+			// 1 (heading-to-paragraph) + 6 (heading levels) + 1 (quote) = 8
+			expect( registerShortcut ).toHaveBeenCalledTimes( 8 );
+		} );
+
+		test( 'binds all 8 useShortcut handlers', () => {
+			renderComponent();
+
+			expect( useShortcut ).toHaveBeenCalledTimes( 8 );
+			expect( Object.keys( shortcutHandlers ) ).toHaveLength( 8 );
+		} );
+	} );
+
+	// -------------------------------------------------------------------------
+	// Heading transform — early exits
+	// -------------------------------------------------------------------------
+
+	describe( 'Heading Transform — Early Exits', () => {
+		test( 'does nothing when no block is selected', () => {
+			getSelectedBlockClientId.mockReturnValue( null );
+			renderComponent();
+
+			fireShortcut( 'press-this/transform-paragraph-to-heading-1' );
+
+			expect( replaceBlocks ).not.toHaveBeenCalled();
+		} );
+
+		test( 'does nothing for unsupported block types', () => {
+			getSelectedBlockClientId.mockReturnValue( 'block-1' );
+			getBlockName.mockReturnValue( 'core/image' );
+			renderComponent();
+
+			fireShortcut( 'press-this/transform-paragraph-to-heading-1' );
+
+			expect( replaceBlocks ).not.toHaveBeenCalled();
+		} );
+
+		test( 'does nothing when paragraph is already selected and level is 0', () => {
+			getSelectedBlockClientId.mockReturnValue( 'block-1' );
+			getBlockName.mockReturnValue( 'core/paragraph' );
+			getBlockAttributes.mockReturnValue( { content: 'Hello' } );
+			renderComponent();
+
+			fireShortcut( 'press-this/transform-heading-to-paragraph' );
+
+			expect( replaceBlocks ).not.toHaveBeenCalled();
+		} );
+
+		test( 'does nothing when heading is already at target level', () => {
+			getSelectedBlockClientId.mockReturnValue( 'block-1' );
+			getBlockName.mockReturnValue( 'core/heading' );
+			getBlockAttributes.mockReturnValue( {
+				content: 'Hello',
+				level: 3,
+			} );
+			renderComponent();
+
+			fireShortcut( 'press-this/transform-paragraph-to-heading-3' );
+
+			expect( replaceBlocks ).not.toHaveBeenCalled();
+		} );
+	} );
+
+	// -------------------------------------------------------------------------
+	// Heading transform — paragraph to heading
+	// -------------------------------------------------------------------------
+
+	describe( 'Heading Transform — Paragraph to Heading', () => {
+		test( 'transforms paragraph to heading with correct level', () => {
+			getSelectedBlockClientId.mockReturnValue( 'block-1' );
+			getBlockName.mockReturnValue( 'core/paragraph' );
+			getBlockAttributes.mockReturnValue( { content: 'Hello world' } );
+			renderComponent();
+
+			fireShortcut( 'press-this/transform-paragraph-to-heading-2' );
+
+			expect( createBlock ).toHaveBeenCalledWith( 'core/heading', {
+				content: 'Hello world',
+				level: 2,
+			} );
+			expect( replaceBlocks ).toHaveBeenCalledWith(
+				'block-1',
+				expect.objectContaining( { name: 'core/heading' } )
+			);
+		} );
+
+		test( 'transforms heading to a different heading level', () => {
+			getSelectedBlockClientId.mockReturnValue( 'block-1' );
+			getBlockName.mockReturnValue( 'core/heading' );
+			getBlockAttributes.mockReturnValue( {
+				content: 'Title',
+				level: 2,
+			} );
+			renderComponent();
+
+			fireShortcut( 'press-this/transform-paragraph-to-heading-4' );
+
+			expect( createBlock ).toHaveBeenCalledWith( 'core/heading', {
+				content: 'Title',
+				level: 4,
+			} );
+		} );
+	} );
+
+	// -------------------------------------------------------------------------
+	// Heading transform — heading to paragraph
+	// -------------------------------------------------------------------------
+
+	describe( 'Heading Transform — Heading to Paragraph', () => {
+		test( 'transforms heading to paragraph', () => {
+			getSelectedBlockClientId.mockReturnValue( 'block-1' );
+			getBlockName.mockReturnValue( 'core/heading' );
+			getBlockAttributes.mockReturnValue( {
+				content: 'Title',
+				level: 2,
+			} );
+			renderComponent();
+
+			fireShortcut( 'press-this/transform-heading-to-paragraph' );
+
+			expect( createBlock ).toHaveBeenCalledWith(
+				'core/paragraph',
+				expect.objectContaining( { content: 'Title' } )
+			);
+			// Paragraph should not have a level attribute.
+			expect( createBlock.mock.calls[ 0 ][ 1 ] ).not.toHaveProperty(
+				'level'
+			);
+		} );
+	} );
+
+	// -------------------------------------------------------------------------
+	// Heading transform — alignment preservation
+	// -------------------------------------------------------------------------
+
+	describe( 'Heading Transform — Alignment Preservation', () => {
+		test( 'preserves textAlign attribute', () => {
+			getSelectedBlockClientId.mockReturnValue( 'block-1' );
+			getBlockName.mockReturnValue( 'core/paragraph' );
+			getBlockAttributes.mockReturnValue( {
+				content: 'Centered',
+				textAlign: 'center',
+			} );
+			renderComponent();
+
+			fireShortcut( 'press-this/transform-paragraph-to-heading-1' );
+
+			expect( createBlock ).toHaveBeenCalledWith(
+				'core/heading',
+				expect.objectContaining( {
+					style: { typography: { textAlign: 'center' } },
+				} )
+			);
+		} );
+
+		test( 'preserves style.typography.textAlign format', () => {
+			getSelectedBlockClientId.mockReturnValue( 'block-1' );
+			getBlockName.mockReturnValue( 'core/heading' );
+			getBlockAttributes.mockReturnValue( {
+				content: 'Right-aligned',
+				level: 2,
+				style: { typography: { textAlign: 'right' } },
+			} );
+			renderComponent();
+
+			fireShortcut( 'press-this/transform-heading-to-paragraph' );
+
+			expect( createBlock ).toHaveBeenCalledWith(
+				'core/paragraph',
+				expect.objectContaining( {
+					style: { typography: { textAlign: 'right' } },
+				} )
+			);
+		} );
+
+		test( 'does not add style when no alignment exists', () => {
+			getSelectedBlockClientId.mockReturnValue( 'block-1' );
+			getBlockName.mockReturnValue( 'core/paragraph' );
+			getBlockAttributes.mockReturnValue( { content: 'Plain' } );
+			renderComponent();
+
+			fireShortcut( 'press-this/transform-paragraph-to-heading-1' );
+
+			expect( createBlock.mock.calls[ 0 ][ 1 ] ).not.toHaveProperty(
+				'style'
+			);
+		} );
+	} );
+
+	// -------------------------------------------------------------------------
+	// Quote toggle — paragraph to quote
+	// -------------------------------------------------------------------------
+
+	describe( 'Quote Toggle — Paragraph to Quote', () => {
+		test( 'wraps paragraph content in a quote with inner paragraph', () => {
+			getSelectedBlockClientId.mockReturnValue( 'block-1' );
+			getBlockName.mockReturnValue( 'core/paragraph' );
+			getBlockAttributes.mockReturnValue( {
+				content: 'Quoted text',
+			} );
+			renderComponent();
+
+			fireShortcut( 'press-this/transform-quote-toggle' );
+
+			// Inner paragraph created first.
+			expect( createBlock ).toHaveBeenCalledWith( 'core/paragraph', {
+				content: 'Quoted text',
+			} );
+			// Outer quote wraps the inner paragraph.
+			expect( createBlock ).toHaveBeenCalledWith(
+				'core/quote',
+				{},
+				expect.arrayContaining( [
+					expect.objectContaining( { name: 'core/paragraph' } ),
+				] )
+			);
+			expect( replaceBlocks ).toHaveBeenCalledWith(
+				'block-1',
+				expect.objectContaining( { name: 'core/quote' } )
+			);
+		} );
+	} );
+
+	// -------------------------------------------------------------------------
+	// Quote toggle — quote to paragraphs (modern format)
+	// -------------------------------------------------------------------------
+
+	describe( 'Quote Toggle — Quote to Paragraphs (Modern)', () => {
+		test( 'extracts inner blocks from quote', () => {
+			getSelectedBlockClientId.mockReturnValue( 'block-1' );
+			getBlockName.mockReturnValue( 'core/quote' );
+			getBlock.mockReturnValue( {
+				innerBlocks: [
+					{
+						name: 'core/paragraph',
+						attributes: { content: 'First' },
+						innerBlocks: [],
+					},
+					{
+						name: 'core/paragraph',
+						attributes: { content: 'Second' },
+						innerBlocks: [],
+					},
+				],
+			} );
+			renderComponent();
+
+			fireShortcut( 'press-this/transform-quote-toggle' );
+
+			expect( replaceBlocks ).toHaveBeenCalledWith(
+				'block-1',
+				expect.arrayContaining( [
+					expect.objectContaining( {
+						name: 'core/paragraph',
+						attributes: expect.objectContaining( {
+							content: 'First',
+						} ),
+					} ),
+					expect.objectContaining( {
+						name: 'core/paragraph',
+						attributes: expect.objectContaining( {
+							content: 'Second',
+						} ),
+					} ),
+				] )
+			);
+		} );
+
+		test( 'preserves nested innerBlocks when unwrapping quote', () => {
+			const nestedInnerBlocks = [
+				{
+					name: 'core/list-item',
+					attributes: { content: 'item' },
+					innerBlocks: [],
+				},
+			];
+			getSelectedBlockClientId.mockReturnValue( 'block-1' );
+			getBlockName.mockReturnValue( 'core/quote' );
+			getBlock.mockReturnValue( {
+				innerBlocks: [
+					{
+						name: 'core/list',
+						attributes: {},
+						innerBlocks: nestedInnerBlocks,
+					},
+				],
+			} );
+			renderComponent();
+
+			fireShortcut( 'press-this/transform-quote-toggle' );
+
+			// createBlock should receive the nested innerBlocks as third arg.
+			expect( createBlock ).toHaveBeenCalledWith(
+				'core/list',
+				expect.any( Object ),
+				nestedInnerBlocks
+			);
+		} );
+	} );
+
+	// -------------------------------------------------------------------------
+	// Quote toggle — quote to paragraph (legacy format)
+	// -------------------------------------------------------------------------
+
+	describe( 'Quote Toggle — Quote to Paragraph (Legacy)', () => {
+		test( 'falls back to value attribute when innerBlocks is empty', () => {
+			getSelectedBlockClientId.mockReturnValue( 'block-1' );
+			getBlockName.mockReturnValue( 'core/quote' );
+			getBlock.mockReturnValue( { innerBlocks: [] } );
+			getBlockAttributes.mockReturnValue( {
+				value: 'Legacy quote content',
+			} );
+			renderComponent();
+
+			fireShortcut( 'press-this/transform-quote-toggle' );
+
+			expect( createBlock ).toHaveBeenCalledWith( 'core/paragraph', {
+				content: 'Legacy quote content',
+			} );
+		} );
+
+		test( 'uses empty string when no value attribute exists', () => {
+			getSelectedBlockClientId.mockReturnValue( 'block-1' );
+			getBlockName.mockReturnValue( 'core/quote' );
+			getBlock.mockReturnValue( { innerBlocks: [] } );
+			getBlockAttributes.mockReturnValue( {} );
+			renderComponent();
+
+			fireShortcut( 'press-this/transform-quote-toggle' );
+
+			expect( createBlock ).toHaveBeenCalledWith( 'core/paragraph', {
+				content: '',
+			} );
+		} );
+	} );
+
+	// -------------------------------------------------------------------------
+	// Quote toggle — no-op for other block types
+	// -------------------------------------------------------------------------
+
+	describe( 'Quote Toggle — No-op', () => {
+		test( 'does nothing for non-paragraph/quote blocks', () => {
+			getSelectedBlockClientId.mockReturnValue( 'block-1' );
+			getBlockName.mockReturnValue( 'core/heading' );
+			renderComponent();
+
+			fireShortcut( 'press-this/transform-quote-toggle' );
+
+			expect( replaceBlocks ).not.toHaveBeenCalled();
+		} );
+
+		test( 'does nothing when no block is selected', () => {
+			getSelectedBlockClientId.mockReturnValue( null );
+			renderComponent();
+
+			fireShortcut( 'press-this/transform-quote-toggle' );
+
+			expect( replaceBlocks ).not.toHaveBeenCalled();
+		} );
+	} );
+} );


### PR DESCRIPTION
## Summary

Register keyboard shortcuts for block-level transforms, addressing the block transform portion of #81. The issue reported that Ctrl+Alt+Q (toggle blockquote) no longer works — that was a classic TinyMCE shortcut that doesn't exist in the block editor. This PR adds equivalent functionality using Gutenberg's keyboard shortcuts infrastructure.

New `BlockTransformShortcuts` component registers shortcuts via the `@wordpress/keyboard-shortcuts` store and uses `replaceBlocks` to perform transforms:

- **Access+1 through Access+6** — transform paragraph/heading to heading level 1-6
- **Access+0 / Access+7** — transform heading back to paragraph
- **Access+Q** — toggle between paragraph and quote (new shortcut, not in Gutenberg)

The heading transforms mirror Gutenberg's internal `BlockKeyboardShortcuts` from `@wordpress/block-library`, which Press This doesn't render since it uses `BlockEditorProvider` directly. The quote toggle is new — there's no dedicated shortcut for it in Gutenberg.

Also adds `docs/keyboard-shortcuts.md` documenting all keyboard shortcuts available in Press This and which ones from the full editor aren't yet supported.

Rich text format shortcuts (Ctrl+B, Ctrl+K, etc.) are handled separately in PR #83. Undo/redo is handled in PR #78.

See #81

## Test plan

- [ ] Open Press This and type text in a paragraph block
- [ ] Press Ctrl+Alt+1 (Windows/Linux) or Ctrl+Option+1 (Mac) — should transform to H1
- [ ] Press Ctrl+Alt+2 — should transform to H2
- [ ] Press Ctrl+Alt+0 — should transform back to paragraph
- [ ] Press Ctrl+Alt+Q on a paragraph — should wrap it in a blockquote
- [ ] Press Ctrl+Alt+Q on the quote — should unwrap back to paragraph(s)
- [ ] Verify transforms preserve the text content
- [ ] Verify shortcuts don't fire when no block is selected
- [ ] Verify shortcuts only affect paragraph, heading, and quote blocks (not images, lists, etc.)