### PR TITLE
fix: harden E2E auth validation and response guard

### DIFF
--- a/tests/e2e/auth-access.spec.js
+++ b/tests/e2e/auth-access.spec.js
@@ -44,11 +44,15 @@ test.describe( 'Auth & Access Control', () => {
 		// Navigate to Press This - should get an error or redirect.
 		const response = await page.goto( '/wp-admin/press-this.php' );
 
-		if ( response ) {
-			// WordPress typically returns 403 or redirects for unauthorized access.
-			// It may also return 200 with a wp_die() error page.
-			expect( [ 200, 302, 403 ] ).toContain( response.status() );
-		}
+		// Ensure navigation produced an HTTP response so access control is actually tested.
+		expect(
+			response,
+			'Navigation to /wp-admin/press-this.php returned null; ensure WordPress is reachable.'
+		).not.toBeNull();
+
+		// WordPress typically returns 403 or redirects for unauthorized access.
+		// It may also return 200 with a wp_die() error page.
+		expect( [ 200, 302, 403 ] ).toContain( response.status() );
 
 		// The page should NOT contain the Press This app regardless of HTTP status.
 		const appVisible = await page

--- a/tests/e2e/auth-access.spec.js
+++ b/tests/e2e/auth-access.spec.js
@@ -43,12 +43,14 @@ test.describe( 'Auth & Access Control', () => {
 
 		// Navigate to Press This - should get an error or redirect.
 		const response = await page.goto( '/wp-admin/press-this.php' );
-		const status = response.status();
 
-		// WordPress typically returns 403 or redirects for unauthorized access.
-		expect( [ 403, 302 ] ).toContain( status );
+		if ( response ) {
+			// WordPress typically returns 403 or redirects for unauthorized access.
+			// It may also return 200 with a wp_die() error page.
+			expect( [ 200, 302, 403 ] ).toContain( response.status() );
+		}
 
-		// The page should NOT contain the Press This app.
+		// The page should NOT contain the Press This app regardless of HTTP status.
 		const appVisible = await page
 			.locator( '#press-this-app' )
 			.isVisible()

--- a/tests/e2e/utils/auth.js
+++ b/tests/e2e/utils/auth.js
@@ -32,7 +32,21 @@ async function wpLogin( page, username = 'admin', password = 'password' ) {
  */
 async function ensureAdminAuth( browser ) {
 	if ( fs.existsSync( ADMIN_AUTH_FILE ) ) {
-		return;
+		// Validate stored state is still usable.
+		const context = await browser.newContext( {
+			storageState: ADMIN_AUTH_FILE,
+		} );
+		const page = await context.newPage();
+		await page.goto( '/wp-admin/' );
+		const url = page.url();
+		await context.close();
+
+		if ( ! url.includes( 'wp-login.php' ) ) {
+			return;
+		}
+
+		// Stored state is stale — remove and re-login below.
+		fs.unlinkSync( ADMIN_AUTH_FILE );
 	}
 
 	fs.mkdirSync( AUTH_DIR, { recursive: true } );

--- a/tests/e2e/utils/auth.js
+++ b/tests/e2e/utils/auth.js
@@ -33,15 +33,28 @@ async function wpLogin( page, username = 'admin', password = 'password' ) {
 async function ensureAdminAuth( browser ) {
 	if ( fs.existsSync( ADMIN_AUTH_FILE ) ) {
 		// Validate stored state is still usable.
+		let shouldRefreshState = false;
 		const context = await browser.newContext( {
 			storageState: ADMIN_AUTH_FILE,
 		} );
-		const page = await context.newPage();
-		await page.goto( '/wp-admin/' );
-		const url = page.url();
-		await context.close();
 
-		if ( ! url.includes( 'wp-login.php' ) ) {
+		try {
+			const page = await context.newPage();
+			await page.goto( '/wp-admin/' );
+			const url = page.url();
+
+			if ( url.includes( 'wp-login.php' ) ) {
+				// Redirected to login — stored state is stale.
+				shouldRefreshState = true;
+			}
+		} catch {
+			// Navigation failed — treat stored state as invalid.
+			shouldRefreshState = true;
+		} finally {
+			await context.close();
+		}
+
+		if ( ! shouldRefreshState ) {
 			return;
 		}
 


### PR DESCRIPTION
## Summary

Addresses remaining Copilot review feedback on #88:

- **Stale auth state**: `ensureAdminAuth()` now validates stored auth by navigating to `/wp-admin/` instead of only checking file existence. Deletes stale state and re-authenticates when needed.
- **Null response guard**: The subscriber access test now guards against `page.goto()` returning `null` and accepts HTTP 200 (WordPress `wp_die()` error page) alongside 302/403.

## Test plan

- [ ] `npm run test:e2e` passes with fresh `.auth/` state
- [ ] `npm run test:e2e` passes after deleting wp-env containers (stale auth scenario)