### PR TITLE
Remove auto-suggestion of link post format

### DIFF
--- a/class-wp-press-this-plugin.php
+++ b/class-wp-press-this-plugin.php
@@ -1331,7 +1331,7 @@ class WP_Press_This_Plugin {
 	 *                    - 's'       (string) Selected text from the page.
 	 *                    - '_images' (array)  Scraped image URLs.
 	 *                    - '_embeds' (array)  Scraped embed URLs.
-	 * @return string Suggested post format ('video', 'quote') or empty string for standard.
+	 * @return string Suggested post format ('video', 'quote', or any format via filter) or empty string for standard.
 	 */
 	public function get_suggested_post_format( $data ) {
 		/**

--- a/class-wp-press-this-plugin.php
+++ b/class-wp-press-this-plugin.php
@@ -1386,11 +1386,10 @@ class WP_Press_This_Plugin {
 			}
 		}
 
-		// Priority 3: Check for link-only content.
-		// When only a URL is provided with no other content, suggest link format.
-		if ( empty( $suggested_format ) && ! empty( $data['u'] ) && empty( $data['s'] ) && empty( $data['_images'] ) && empty( $data['_embeds'] ) ) {
-			$suggested_format = 'link';
-		}
+		// Priority 3 (removed): Previously auto-suggested 'link' format when only
+		// a URL was provided with no other content. Removed because scraping often
+		// fails to find images/embeds, causing unexpected link format suggestions.
+		// See https://github.com/WordPress/press-this/issues/94
 
 		// Note: The default format filter is NOT applied here.
 		// It's passed separately via postFormatDefault to allow JS detection

--- a/class-wp-press-this-plugin.php
+++ b/class-wp-press-this-plugin.php
@@ -1286,10 +1286,7 @@ class WP_Press_This_Plugin {
 	 *    longer than 50 characters and does not contain URLs. This indicates
 	 *    the user likely wants to quote the selected passage.
 	 *
-	 * 4. **Link format**: Suggested when only a URL is provided with no
-	 *    selected text, images, or embeds. This indicates a simple link share.
-	 *
-	 * 5. **Standard format**: Used when none of the above conditions are met.
+	 * 4. **Standard format**: Used when none of the above conditions are met.
 	 *
 	 * Note: The `press_this_default_post_format` filter is NOT applied here.
 	 * It is passed separately to JavaScript to allow client-side detection
@@ -1334,7 +1331,7 @@ class WP_Press_This_Plugin {
 	 *                    - 's'       (string) Selected text from the page.
 	 *                    - '_images' (array)  Scraped image URLs.
 	 *                    - '_embeds' (array)  Scraped embed URLs.
-	 * @return string Suggested post format ('video', 'quote', 'link') or empty string for standard.
+	 * @return string Suggested post format ('video', 'quote') or empty string for standard.
 	 */
 	public function get_suggested_post_format( $data ) {
 		/**
@@ -1386,10 +1383,8 @@ class WP_Press_This_Plugin {
 			}
 		}
 
-		// Priority 3 (removed): Previously auto-suggested 'link' format when only
-		// a URL was provided with no other content. Removed because scraping often
-		// fails to find images/embeds, causing unexpected link format suggestions.
-		// See https://github.com/WordPress/press-this/issues/94
+		// Link format auto-suggestion was removed because scraping often fails to
+		// find images/embeds, causing unexpected format changes. See issue #94.
 
 		// Note: The default format filter is NOT applied here.
 		// It's passed separately via postFormatDefault to allow JS detection

--- a/src/hooks/use-post-format-suggestion.js
+++ b/src/hooks/use-post-format-suggestion.js
@@ -175,45 +175,6 @@ function hasQuoteContent( content = '' ) {
 }
 
 /**
- * Check if content is link-focused.
- *
- * @param {string} content   Post content to analyze.
- * @param {string} sourceUrl The source URL being clipped.
- * @return {boolean} True if link-focused content detected.
- */
-function hasLinkContent( content = '', sourceUrl = '' ) {
-	if ( ! content && ! sourceUrl ) {
-		return false;
-	}
-
-	// If we have a source URL but very little content, it's link-focused.
-	if ( sourceUrl && ( ! content || content.length < 100 ) ) {
-		return true;
-	}
-
-	if ( ! content ) {
-		return false;
-	}
-
-	// Count links in content.
-	const linkCount = ( content.match( /<a[^>]+href/gi ) || [] ).length;
-	const paragraphCount = ( content.match( /<p[^>]*>/gi ) || [] ).length;
-
-	// If we have many links relative to paragraphs, suggest link format.
-	if ( paragraphCount > 0 && linkCount / paragraphCount > 0.8 ) {
-		return true;
-	}
-
-	// Check if content is primarily a URL.
-	const trimmedContent = content.replace( /<[^>]+>/g, '' ).trim();
-	if ( /^https?:\/\/[^\s]+$/.test( trimmedContent ) ) {
-		return true;
-	}
-
-	return false;
-}
-
-/**
  * Check if content is status/social media-like.
  *
  * @param {string} content   Post content to analyze.

--- a/src/hooks/use-post-format-suggestion.js
+++ b/src/hooks/use-post-format-suggestion.js
@@ -2,7 +2,7 @@
  * usePostFormatSuggestion Hook
  *
  * Analyzes content to suggest an appropriate post format based on content type.
- * Detects video embeds, quote-heavy content, and link-focused content.
+ * Detects video embeds, audio embeds, social/status posts, quote-heavy content, and images.
  *
  * @package
  */

--- a/src/hooks/use-post-format-suggestion.js
+++ b/src/hooks/use-post-format-suggestion.js
@@ -369,10 +369,8 @@ export function suggestPostFormat( {
 		return 'image';
 	}
 
-	// Check for link-focused content.
-	if ( isFormatAvailable( 'link' ) && hasLinkContent( content, sourceUrl ) ) {
-		return 'link';
-	}
+	// Note: Link format detection removed — too easily triggered by normal
+	// pages with short content. See https://github.com/WordPress/press-this/issues/94
 
 	// Priority 4: Fallback to default format from PHP filter.
 	if ( defaultFormat ) {

--- a/tests/hooks/use-post-format-suggestion.test.js
+++ b/tests/hooks/use-post-format-suggestion.test.js
@@ -240,25 +240,25 @@ describe( 'suggestPostFormat', () => {
 		} );
 	} );
 
-	describe( 'Link Detection', () => {
-		test( 'detects URL with little content', () => {
+	describe( 'Link Detection (removed)', () => {
+		test( 'does not auto-suggest link format for URL with little content', () => {
 			const result = suggestPostFormat( {
 				sourceUrl: 'https://example.com/article',
 				content: '',
 				availableFormats,
 			} );
 
-			expect( result ).toBe( 'link' );
+			expect( result ).toBe( '' );
 		} );
 
-		test( 'detects URL-only content', () => {
+		test( 'does not auto-suggest link format for URL-only content', () => {
 			const result = suggestPostFormat( {
 				content: 'https://example.com/article',
 				sourceUrl: 'https://example.com/article',
 				availableFormats,
 			} );
 
-			expect( result ).toBe( 'link' );
+			expect( result ).toBe( '' );
 		} );
 	} );
 
@@ -286,8 +286,8 @@ describe( 'suggestPostFormat', () => {
 				availableFormats: limitedFormats,
 			} );
 
-			// Video not available, should fall back to link
-			expect( result ).toBe( 'link' );
+			// Video not available and link detection removed, so no match
+			expect( result ).toBe( '' );
 		} );
 
 		test( 'defaultFormat used even if not in availableFormats', () => {

--- a/tests/hooks/use-post-format-suggestion.test.js
+++ b/tests/hooks/use-post-format-suggestion.test.js
@@ -54,9 +54,9 @@ describe( 'suggestPostFormat', () => {
 		test( 'defaultFormat is used when nothing else matches', () => {
 			const result = suggestPostFormat( {
 				defaultFormat: 'aside',
-				// Content that won't match any detection (long enough to not be link-focused)
+				// Content that won't match any detection.
 				content:
-					'<p>This is a regular paragraph with enough content that it will not trigger link detection.</p><p>Another paragraph here.</p>',
+					'<p>This is a regular paragraph with enough content.</p><p>Another paragraph here.</p>',
 				availableFormats,
 			} );
 
@@ -65,9 +65,9 @@ describe( 'suggestPostFormat', () => {
 
 		test( 'returns empty string when nothing matches and no default', () => {
 			const result = suggestPostFormat( {
-				// Content that won't match any detection
+				// Content that won't match any detection.
 				content:
-					'<p>This is a regular paragraph with enough content that it will not trigger link detection.</p><p>Another paragraph here.</p>',
+					'<p>This is a regular paragraph with enough content.</p><p>Another paragraph here.</p>',
 				availableFormats,
 			} );
 

--- a/tests/php/test-post-format-filters.php
+++ b/tests/php/test-post-format-filters.php
@@ -244,11 +244,11 @@ class Test_Post_Format_Filters extends BaseTestCase {
 	}
 
 	/**
-	 * Test: Link detection for URL-only content.
+	 * Test: URL-only content no longer suggests link format.
 	 *
 	 * @covers WP_Press_This_Plugin::get_suggested_post_format
 	 */
-	public function test_link_detection_for_url_only() {
+	public function test_url_only_does_not_suggest_link() {
 		$data = array(
 			'u' => 'https://example.com/article',
 			// No selected text, images, or embeds.
@@ -256,7 +256,7 @@ class Test_Post_Format_Filters extends BaseTestCase {
 
 		$result = $this->plugin->get_suggested_post_format( $data );
 
-		$this->assertEquals( 'link', $result );
+		$this->assertEquals( '', $result );
 	}
 
 	/**


### PR DESCRIPTION
## Summary

- Removes automatic link format detection that triggered whenever a page had no scraped images or embeds
- Scraping is inherently unreliable, so many normal pages were silently getting the link format instead of standard
- Users can still manually select link format via the dropdown, and the `press_this_post_format_suggestion` filter still allows plugins to suggest it

## Test plan

- [ ] Press This a normal webpage without selecting text — format should be Standard, not Link
- [ ] Press This a YouTube URL — format should still auto-detect as Video
- [ ] Select a long passage of text and Press This — format should still auto-detect as Quote
- [ ] Manually change format to Link via dropdown — should still work

Fixes #94