### PR TITLE
Externalize format-library to fix missing link button

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -24,6 +24,7 @@ const wordPressExternals = {
 	'@wordpress/keycodes': [ 'wp', 'keycodes' ],
 	'@wordpress/primitives': [ 'wp', 'primitives' ],
 	'@wordpress/blob': [ 'wp', 'blob' ],
+	'@wordpress/format-library': [ 'wp', 'formatLibrary' ],
 	// Note: @wordpress/icons is NOT externalized - it gets bundled since
 	// @wordpress/components needs it internally and wp.icons may not be available.
 };


### PR DESCRIPTION
## Summary

- Adds `@wordpress/format-library` to the webpack externals map so it shares the same global `wp.richText` format registry as the externalized `@wordpress/block-editor`
- Without this, the format-library's format types (bold, italic, **link**) were registered in a private bundled registry that the block editor toolbar never read from, so the link button was missing

## Test plan

- [x] Open Press This editor
- [x] Select text in a paragraph block
- [x] Verify the link button appears in the fixed toolbar
- [x] Click the link button (or use Cmd/Ctrl+K) and confirm the link popover opens
- [x] Add a link and verify it is saved correctly

Fixes #95