### PR TITLE
Add .phpunit.result.cache to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,6 +21,9 @@ composer.lock
 .DS_Store
 Thumbs.db
 
+# Test cache
+.phpunit.result.cache
+
 # Debug logs
 *.log
 npm-debug.log*


### PR DESCRIPTION
## Summary

- Adds `.phpunit.result.cache` to `.gitignore` to prevent PHPUnit's result cache file from being committed.