### PR TITLE
Fix test expecting removed link format suggestion

### DIFF
--- a/tests/php/test-plugin-class-extended.php
+++ b/tests/php/test-plugin-class-extended.php
@@ -923,13 +923,17 @@ class Test_WP_Press_This_Plugin_Extended extends BaseTestCase {
 	}
 
 	/**
-	 * Test suggested format: link when only URL.
+	 * Test suggested format: URL-only no longer suggests link.
+	 *
+	 * Link format auto-suggestion was removed because scraping often fails to
+	 * find images/embeds, causing unexpected link format suggestions.
+	 * See https://github.com/WordPress/press-this/issues/94
 	 */
 	public function test_suggested_post_format_link() {
 		$data = array( 'u' => 'https://example.com/article' );
 
 		$result = $this->plugin->get_suggested_post_format( $data );
-		$this->assertEquals( 'link', $result );
+		$this->assertEquals( '', $result );
 	}
 
 	/**


### PR DESCRIPTION
## Summary

- The test coverage audit (PR #88) added `test_suggested_post_format_link` expecting `'link'`
- PR #96 separately removed link format auto-suggestion (fixes #94), making the function return `''` instead
- These merged independently, leaving a failing test on trunk
- Updates the test to expect `''` and adds a doc comment explaining the removal

## Test plan

- [x] `vendor/bin/phpunit --filter test_suggested_post_format_link` passes
- [x] Full PHP test suite passes (255 tests, 502 assertions)