### PR TITLE
Remove duplicate plugin mount from wp-env config

### DIFF
--- a/.wp-env.json
+++ b/.wp-env.json
@@ -2,9 +2,7 @@
 	"$schema": "https://schemas.wp.org/trunk/wp-env.json",
 	"core": null,
 	"phpVersion": "8.2",
-	"plugins": [
-		"."
-	],
+	"plugins": [],
 	"themes": [],
 	"config": {
 		"WP_DEBUG": true,

--- a/.wp-env.json
+++ b/.wp-env.json
@@ -13,6 +13,9 @@
 		"wp-content/plugins/press-this": ".",
 		"wp-content/mu-plugins": "./tests/mu-plugins"
 	},
+	"lifecycleScripts": {
+		"afterStart": "npx wp-env run cli wp plugin activate press-this"
+	},
 	"env": {
 		"tests": {
 			"phpVersion": "8.2",


### PR DESCRIPTION
## Summary

- Remove `"."` from the `plugins` array in `.wp-env.json` to eliminate a duplicate plugin mount
- The `mappings` section already mounts the project as `wp-content/plugins/press-this`, so the `plugins` entry caused wp-env to mount it a second time under the workspace directory name (e.g. `bamako`)
- With both mounts, `wp plugin list` showed two entries: the workspace-named one (active) and `press-this` (inactive) — meaning the plugin ran under the wrong directory name

## Test plan

- [x] `wp-env start` succeeds
- [x] `wp plugin list` shows only `press-this` (no duplicate under workspace dir name)
- [x] All 24 e2e tests pass