### PR TITLE
Cache Playwright browsers in CI

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -117,8 +117,24 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
+      - name: Get Playwright version
+        id: playwright-version
+        run: echo "version=$(npx playwright --version | awk '{print $2}')" >> $GITHUB_OUTPUT
+
+      - name: Cache Playwright browsers
+        id: playwright-cache
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/ms-playwright
+          key: ${{ runner.os }}-playwright-${{ steps.playwright-version.outputs.version }}
+
       - name: Install Playwright browsers
+        if: steps.playwright-cache.outputs.cache-hit != 'true'
         run: npx playwright install chromium --with-deps
+
+      - name: Install Playwright system dependencies
+        if: steps.playwright-cache.outputs.cache-hit == 'true'
+        run: npx playwright install-deps chromium
 
       - name: Build assets
         run: npm run build


### PR DESCRIPTION
## Summary

- Caches `~/.cache/ms-playwright` in the e2e-tests job, keyed on `runner.os` + Playwright version
- Skips browser download on cache hit; only installs OS system libraries (`playwright install-deps chromium`)
- Reduces CI time and network usage for repeated runs at the same Playwright version

## Test plan

- [ ] Verify e2e-tests job passes on the first run (cold cache, browsers downloaded)
- [ ] Verify e2e-tests job passes on a second run (warm cache, browser download skipped, system deps installed)
- [ ] Confirm cache key updates when Playwright version changes