### PR TITLE
Bump version to 2.0.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "press-this",
-  "version": "2.0.2-beta",
+  "version": "2.0.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "press-this",
-      "version": "2.0.2-beta",
+      "version": "2.0.2",
       "license": "GPL-2.0+",
       "dependencies": {
         "@wordpress/a11y": "^4.40.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "press-this",
-  "version": "2.0.2-beta",
+  "version": "2.0.2",
   "description": "A little tool that lets you grab bits of the web and create new posts with ease.",
   "repository": {
     "type": "git",

--- a/press-this-plugin.php
+++ b/press-this-plugin.php
@@ -5,7 +5,7 @@
  * Plugin Name: Press This
  * Plugin URI:  https://wordpress.org
  * Description: A little tool that lets you grab bits of the web and create new posts with ease. Now powered by the Gutenberg block editor.
- * Version:     2.0.2-beta
+ * Version:     2.0.2
  * Author:      WordPress Contributors
  * Author URI:  https://wordpress.org
  * License:     GPL-2.0+
@@ -34,7 +34,7 @@
  * @since 1.0.0
  * @since 2.0.1 Updated for Gutenberg block editor integration.
  */
-define( 'PRESS_THIS__VERSION', '2.0.2-beta' );
+define( 'PRESS_THIS__VERSION', '2.0.2' );
 
 /**
  * Minimum WordPress version required for the Gutenberg features.

--- a/readme.txt
+++ b/readme.txt
@@ -3,7 +3,7 @@ Contributors: kraftbj, wordpressdotorg
 Donate link: http://wordpressfoundation.org/donate/
 Tags: post, quick-post, photo-post, bookmarklet, gutenberg
 Requires at least: 6.9
-Tested up to: 6.9
+Tested up to: 7.0
 Stable tag: 2.0.2
 Requires PHP: 7.4
 License: GPLv2 or later

--- a/readme.txt
+++ b/readme.txt
@@ -125,7 +125,7 @@ All existing hooks continue to work:
 == Upgrade Notice ==
 
 = 2.0.2 =
-Bug fixes and improvements.
+Bug fixes, new keyboard shortcuts, and undo/redo support.
 
 = 2.0.1 =
 Major update: Gutenberg block editor integration, enhanced content extraction, new developer hooks. Backward compatible with existing bookmarklets.
@@ -139,7 +139,18 @@ Restores bookmarklet functionality.
 == Changelog ==
 
 = 2.0.2 =
-* Bug fixes and improvements.
+* **New:** Undo/redo support in the block editor (Ctrl+Z / Ctrl+Shift+Z)
+* **New:** Block transform keyboard shortcuts (e.g. heading, list, quote)
+* **New:** Rich text format keyboard shortcuts via format-library (bold, italic, link, etc.)
+* **New:** Bookmarklet now preserves HTML formatting in text selections
+* **Fix:** Critical error when saving posts with external images in REST context
+* **Fix:** Scraped media inserting at bottom of post instead of cursor position
+* **Fix:** Quote block unwrap losing nested inner blocks
+* **Fix:** Category panel styles not loading and stale search filter results
+* **Fix:** Stale state in category toggle handler
+* **Change:** Removed auto-suggestion of link post format
+* **Change:** Restored category search filter using Gutenberg components
+* **Change:** Requires Node 22
 
 = 2.0.1 =
 * **New:** Gutenberg block editor replaces TinyMCE for modern editing experience

--- a/readme.txt
+++ b/readme.txt
@@ -150,7 +150,6 @@ Restores bookmarklet functionality.
 * **Fix:** Stale state in category toggle handler
 * **Change:** Removed auto-suggestion of link post format
 * **Change:** Restored category search filter using Gutenberg components
-* **Change:** Requires Node 22
 
 = 2.0.1 =
 * **New:** Gutenberg block editor replaces TinyMCE for modern editing experience

--- a/readme.txt
+++ b/readme.txt
@@ -3,7 +3,7 @@ Contributors: kraftbj, wordpressdotorg
 Donate link: http://wordpressfoundation.org/donate/
 Tags: post, quick-post, photo-post, bookmarklet, gutenberg
 Requires at least: 6.9
-Tested up to: 6.7
+Tested up to: 6.9
 Stable tag: 2.0.2
 Requires PHP: 7.4
 License: GPLv2 or later

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Donate link: http://wordpressfoundation.org/donate/
 Tags: post, quick-post, photo-post, bookmarklet, gutenberg
 Requires at least: 6.9
 Tested up to: 6.7
-Stable tag: 2.0.1
+Stable tag: 2.0.2
 Requires PHP: 7.4
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
@@ -124,6 +124,9 @@ All existing hooks continue to work:
 
 == Upgrade Notice ==
 
+= 2.0.2 =
+Bug fixes and improvements.
+
 = 2.0.1 =
 Major update: Gutenberg block editor integration, enhanced content extraction, new developer hooks. Backward compatible with existing bookmarklets.
 
@@ -134,6 +137,9 @@ Fixes styling issues and bumps tested version.
 Restores bookmarklet functionality.
 
 == Changelog ==
+
+= 2.0.2 =
+* Bug fixes and improvements.
 
 = 2.0.1 =
 * **New:** Gutenberg block editor replaces TinyMCE for modern editing experience


### PR DESCRIPTION
## Summary
- Updates version from `2.0.2-beta` to `2.0.2` in plugin header, version constant, package.json, and package-lock.json
- Updates stable tag in readme.txt from `2.0.1` to `2.0.2`
- Adds changelog and upgrade notice entries for 2.0.2