### PR TITLE
CI: Add merge queue support and fix JS lint swallowing

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,0 +1,11 @@
+module.exports = {
+	extends: [ 'plugin:@wordpress/eslint-plugin/recommended' ],
+	rules: {
+		'jsdoc/no-undefined-types': [
+			'error',
+			{
+				definedTypes: [ 'JSX', 'Document', 'Element', 'KeyboardEvent', 'MouseEvent' ],
+			},
+		],
+	},
+};

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -2,9 +2,10 @@ name: Tests
 
 on:
   push:
-    branches: [trunk, modernize/v2]
+    branches: [trunk]
   pull_request:
     branches: [trunk]
+  merge_group:
 
 jobs:
   js-tests:
@@ -36,7 +37,10 @@ jobs:
 
     strategy:
       matrix:
-        php-version: ['7.4', '8.0', '8.1', '8.2']
+        php-version: >-
+          ${{ (github.event_name == 'merge_group' || github.event_name == 'push')
+            && fromJSON('["7.4","8.0","8.1","8.2"]')
+            || fromJSON('["7.4","8.2"]') }}
 
     steps:
       - name: Checkout code
@@ -95,7 +99,6 @@ jobs:
 
       - name: Lint JavaScript
         run: npm run lint
-        continue-on-error: true
 
       - name: Lint PHP
         run: composer php:lint:errors
@@ -157,3 +160,16 @@ jobs:
             test-results/
             playwright-report/
           retention-days: 7
+
+  ci:
+    name: CI
+    if: always()
+    needs: [js-tests, php-tests, lint, e2e-tests]
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check results
+        run: |
+          if [[ "${{ contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled') }}" == "true" ]]; then
+            echo "One or more jobs failed or were cancelled."
+            exit 1
+          fi


### PR DESCRIPTION
## Summary

- Adds `merge_group` trigger so the workflow runs in the GitHub merge queue
- PHP tests run only bookend versions (7.4, 8.2) on PRs for faster feedback; all versions (7.4, 8.0, 8.1, 8.2) run on merge queue and trunk push
- Adds a `CI` gate job that aggregates all job results into a single required status check
- Removes `continue-on-error: true` from the JS lint step so lint failures are no longer silently swallowed
- Removes the dead `modernize/v2` branch from the push trigger

## After merging

Update branch protection for `trunk`:
- Set `CI` as the sole required status check
- Remove any individual job names that were previously required

## Test plan

- [ ] Verify this PR runs PHP tests for only 7.4 and 8.2
- [ ] Verify JS lint failures would block the CI gate job
- [ ] After merging, verify merge queue runs all four PHP versions