### PR TITLE
Fix Scraped Media insertion to respect cursor position

### DIFF
--- a/src/components/ConnectedScrapedMediaPanel.js
+++ b/src/components/ConnectedScrapedMediaPanel.js
@@ -1,0 +1,42 @@
+/**
+ * Connected Scraped Media Panel
+ *
+ * Bridges ScrapedMediaPanel to the block editor store so media is inserted
+ * at the user's current cursor position rather than appended at the end of
+ * the document. Must be rendered inside a BlockEditorProvider.
+ *
+ * @package
+ */
+
+import { useCallback } from '@wordpress/element';
+import { useDispatch, useSelect } from '@wordpress/data';
+import { store as blockEditorStore } from '@wordpress/block-editor';
+
+import ScrapedMediaPanel from './ScrapedMediaPanel';
+
+export default function ConnectedScrapedMediaPanel( props ) {
+	const { insertBlock } = useDispatch( blockEditorStore );
+
+	// `insertBlock(block)` with no index falls back to appending at the end
+	// of the document. Read the live insertion point so the new block lands
+	// where the cursor is — fixes #126.
+	const insertionPoint = useSelect(
+		( select ) => select( blockEditorStore ).getBlockInsertionPoint(),
+		[]
+	);
+
+	const handleInsertBlock = useCallback(
+		( block ) => {
+			insertBlock(
+				block,
+				insertionPoint.index,
+				insertionPoint.rootClientId
+			);
+		},
+		[ insertBlock, insertionPoint.index, insertionPoint.rootClientId ]
+	);
+
+	return (
+		<ScrapedMediaPanel { ...props } onInsertBlock={ handleInsertBlock } />
+	);
+}

--- a/src/components/ConnectedScrapedMediaPanel.js
+++ b/src/components/ConnectedScrapedMediaPanel.js
@@ -12,7 +12,7 @@
  * WordPress dependencies
  */
 import { useCallback } from '@wordpress/element';
-import { useDispatch, useSelect } from '@wordpress/data';
+import { useDispatch, useRegistry } from '@wordpress/data';
 import { store as blockEditorStore } from '@wordpress/block-editor';
 
 /**
@@ -23,44 +23,34 @@ import ScrapedMediaPanel from './ScrapedMediaPanel';
 export default function ConnectedScrapedMediaPanel( props ) {
 	const { insertBlock } = useDispatch( blockEditorStore );
 
-	// `insertBlock(block)` with no index falls back to appending at the end
-	// of the document. Read the live insertion point so the new block lands
-	// where the cursor is — fixes #126.
-	const { canInsert, insertionPoint } = useSelect( ( select ) => {
-		const store = select( blockEditorStore );
-		return {
-			canInsert: store.canInsertBlockType,
-			insertionPoint: store.getBlockInsertionPoint(),
-		};
-	}, [] );
+	// Use the registry of the surrounding BlockEditorProvider so we can
+	// query the freshest state at click time. A render-time useSelect would
+	// close over potentially-stale values for any click that fires before
+	// React commits the next selection change. Reading imperatively here
+	// removes that race entirely.
+	const registry = useRegistry();
 
 	const handleInsertBlock = useCallback(
 		( block ) => {
+			const store = registry.select( blockEditorStore );
+			const { index, rootClientId } = store.getBlockInsertionPoint();
+
 			// If the cursor is inside a container that doesn't allow this
 			// block type (e.g. a core/list, which only accepts list-items),
 			// inserting at the cursor would be silently rejected by the
 			// block editor's INSERT_BLOCKS reducer. Fall back to a top-level
 			// append in that case so the click is never a no-op.
 			if (
-				insertionPoint.rootClientId &&
-				! canInsert( block.name, insertionPoint.rootClientId )
+				rootClientId &&
+				! store.canInsertBlockType( block.name, rootClientId )
 			) {
 				insertBlock( block );
 				return;
 			}
 
-			insertBlock(
-				block,
-				insertionPoint.index,
-				insertionPoint.rootClientId
-			);
+			insertBlock( block, index, rootClientId );
 		},
-		[
-			insertBlock,
-			canInsert,
-			insertionPoint.index,
-			insertionPoint.rootClientId,
-		]
+		[ insertBlock, registry ]
 	);
 
 	return (

--- a/src/components/ConnectedScrapedMediaPanel.js
+++ b/src/components/ConnectedScrapedMediaPanel.js
@@ -8,10 +8,16 @@
  * @package
  */
 
+/**
+ * WordPress dependencies
+ */
 import { useCallback } from '@wordpress/element';
 import { useDispatch, useSelect } from '@wordpress/data';
 import { store as blockEditorStore } from '@wordpress/block-editor';
 
+/**
+ * Internal dependencies
+ */
 import ScrapedMediaPanel from './ScrapedMediaPanel';
 
 export default function ConnectedScrapedMediaPanel( props ) {
@@ -20,20 +26,41 @@ export default function ConnectedScrapedMediaPanel( props ) {
 	// `insertBlock(block)` with no index falls back to appending at the end
 	// of the document. Read the live insertion point so the new block lands
 	// where the cursor is — fixes #126.
-	const insertionPoint = useSelect(
-		( select ) => select( blockEditorStore ).getBlockInsertionPoint(),
-		[]
-	);
+	const { canInsert, insertionPoint } = useSelect( ( select ) => {
+		const store = select( blockEditorStore );
+		return {
+			canInsert: store.canInsertBlockType,
+			insertionPoint: store.getBlockInsertionPoint(),
+		};
+	}, [] );
 
 	const handleInsertBlock = useCallback(
 		( block ) => {
+			// If the cursor is inside a container that doesn't allow this
+			// block type (e.g. a core/list, which only accepts list-items),
+			// inserting at the cursor would be silently rejected by the
+			// block editor's INSERT_BLOCKS reducer. Fall back to a top-level
+			// append in that case so the click is never a no-op.
+			if (
+				insertionPoint.rootClientId &&
+				! canInsert( block.name, insertionPoint.rootClientId )
+			) {
+				insertBlock( block );
+				return;
+			}
+
 			insertBlock(
 				block,
 				insertionPoint.index,
 				insertionPoint.rootClientId
 			);
 		},
-		[ insertBlock, insertionPoint.index, insertionPoint.rootClientId ]
+		[
+			insertBlock,
+			canInsert,
+			insertionPoint.index,
+			insertionPoint.rootClientId,
+		]
 	);
 
 	return (

--- a/src/components/PressThisEditor.js
+++ b/src/components/PressThisEditor.js
@@ -17,7 +17,7 @@ import {
 	useEffect,
 	useRef,
 } from '@wordpress/element';
-import { useSelect, useDispatch } from '@wordpress/data';
+import { useSelect } from '@wordpress/data';
 import { parse } from '@wordpress/blocks';
 import {
 	BlockEditorProvider,
@@ -49,7 +49,7 @@ import { registerCoreBlocks } from '@wordpress/block-library';
  */
 import BlockTransformShortcuts from './BlockTransformShortcuts';
 import LinkEscapeFix from './LinkEscapeFix';
-import ScrapedMediaPanel from './ScrapedMediaPanel';
+import ConnectedScrapedMediaPanel from './ConnectedScrapedMediaPanel';
 import FeaturedImagePanel from './FeaturedImagePanel';
 import CategoryPanel from './CategoryPanel';
 import { isStandaloneMode } from '../utils';
@@ -78,31 +78,6 @@ function SidebarBlockInspector() {
 		>
 			<BlockInspector />
 		</PanelBody>
-	);
-}
-
-/**
- * Connected Scraped Media Panel.
- *
- * Must be rendered inside BlockEditorProvider to access the block editor store.
- * Uses the store's insertBlock action so media is inserted at the cursor
- * position rather than always appended at the end.
- *
- * @param {Object} props Props passed through to ScrapedMediaPanel.
- * @return {JSX.Element|null} ScrapedMediaPanel with store-connected insertion.
- */
-function ConnectedScrapedMediaPanel( props ) {
-	const { insertBlock } = useDispatch( blockEditorStore );
-
-	const handleInsertBlock = useCallback(
-		( block ) => {
-			insertBlock( block );
-		},
-		[ insertBlock ]
-	);
-
-	return (
-		<ScrapedMediaPanel { ...props } onInsertBlock={ handleInsertBlock } />
 	);
 }
 

--- a/tests/components/connected-scraped-media-panel.test.js
+++ b/tests/components/connected-scraped-media-panel.test.js
@@ -23,11 +23,12 @@ let mockCanInsert = jest.fn( () => true );
 
 jest.mock( '@wordpress/data', () => ( {
 	useDispatch: () => ( { insertBlock: mockInsertBlock } ),
-	useSelect: ( fn ) =>
-		fn( () => ( {
+	useRegistry: () => ( {
+		select: () => ( {
 			getBlockInsertionPoint: () => mockInsertionPoint,
 			canInsertBlockType: mockCanInsert,
-		} ) ),
+		} ),
+	} ),
 } ) );
 
 jest.mock( '@wordpress/block-editor', () => ( {

--- a/tests/components/connected-scraped-media-panel.test.js
+++ b/tests/components/connected-scraped-media-panel.test.js
@@ -19,12 +19,14 @@ globalThis.IS_REACT_ACT_ENVIRONMENT = true;
 
 const mockInsertBlock = jest.fn();
 let mockInsertionPoint = { rootClientId: undefined, index: undefined };
+let mockCanInsert = jest.fn( () => true );
 
 jest.mock( '@wordpress/data', () => ( {
 	useDispatch: () => ( { insertBlock: mockInsertBlock } ),
 	useSelect: ( fn ) =>
 		fn( () => ( {
 			getBlockInsertionPoint: () => mockInsertionPoint,
+			canInsertBlockType: mockCanInsert,
 		} ) ),
 } ) );
 
@@ -89,6 +91,7 @@ describe( 'ConnectedScrapedMediaPanel — issue #126 cursor position', () => {
 	beforeEach( () => {
 		mockInsertBlock.mockClear();
 		mockInsertionPoint = { rootClientId: undefined, index: undefined };
+		mockCanInsert = jest.fn( () => true );
 		container = document.createElement( 'div' );
 		document.body.appendChild( container );
 	} );
@@ -166,6 +169,65 @@ describe( 'ConnectedScrapedMediaPanel — issue #126 cursor position', () => {
 		const [ , index, rootClientId ] = mockInsertBlock.mock.calls[ 0 ];
 		expect( index ).toBe( 2 );
 		expect( rootClientId ).toBe( 'parent-id' );
+	} );
+
+	test( 'forwards arbitrary insertion-point indexes (not just 1)', async () => {
+		// Sweep a few values so a regression that hard-codes the index
+		// would not pass the suite.
+		for ( const index of [ 0, 3, 7 ] ) {
+			mockInsertBlock.mockClear();
+			mockInsertionPoint = { rootClientId: undefined, index };
+
+			if ( root ) {
+				await act( async () => {
+					root.unmount();
+				} );
+				root = null;
+			}
+
+			await renderPanel( [
+				'https://www.youtube.com/watch?v=dQw4w9WgXcQ',
+			] );
+
+			const embedButton = container.querySelector(
+				'.press-this-scraped-media__embed-button'
+			);
+			await act( async () => {
+				embedButton.click();
+			} );
+
+			expect( mockInsertBlock.mock.calls[ 0 ][ 1 ] ).toBe( index );
+		}
+	} );
+
+	test( 'falls back to top-level append when canInsertBlockType returns false', async () => {
+		// Cursor inside e.g. a core/list, which only allows core/list-item:
+		// inserting at the cursor would be silently filtered by the editor's
+		// reducer. We should fall back to a top-level append so the user's
+		// click is never a no-op.
+		mockInsertionPoint = { rootClientId: 'list-id', index: 1 };
+		mockCanInsert = jest.fn( ( blockName, rootClientId ) => {
+			return ! ( rootClientId === 'list-id' && blockName === 'core/embed' );
+		} );
+
+		await renderPanel( [
+			'https://www.youtube.com/watch?v=dQw4w9WgXcQ',
+		] );
+
+		const embedButton = container.querySelector(
+			'.press-this-scraped-media__embed-button'
+		);
+		await act( async () => {
+			embedButton.click();
+		} );
+
+		expect( mockInsertBlock ).toHaveBeenCalledTimes( 1 );
+		const args = mockInsertBlock.mock.calls[ 0 ];
+		// Only the block was passed — no index, no rootClientId — so the
+		// reducer appends at the end.
+		expect( args[ 1 ] ).toBeUndefined();
+		expect( args[ 2 ] ).toBeUndefined();
+		expect( mockCanInsert ).toHaveBeenCalledWith( 'core/embed', 'list-id' );
 	} );
 
 	test( 'inserting an image also goes to the cursor index', async () => {

--- a/tests/components/connected-scraped-media-panel.test.js
+++ b/tests/components/connected-scraped-media-panel.test.js
@@ -1,0 +1,214 @@
+/**
+ * Connected Scraped Media Panel — behavior tests.
+ *
+ * Reproduces https://github.com/WordPress/press-this/issues/126:
+ * inserting an embed from the Scraped Media panel must place the new block
+ * at the user's current cursor position, not append it at the end of the
+ * document.
+ *
+ * Strategy: stub the @wordpress packages that ConnectedScrapedMediaPanel and
+ * ScrapedMediaPanel reach into. The stubs let us assert exactly which
+ * arguments the connected handler dispatches to insertBlock — which is the
+ * heart of the bug.
+ *
+ * @package press-this
+ */
+
+// Tell React 18 that act() in this file is the test runner's act.
+globalThis.IS_REACT_ACT_ENVIRONMENT = true;
+
+const mockInsertBlock = jest.fn();
+let mockInsertionPoint = { rootClientId: undefined, index: undefined };
+
+jest.mock( '@wordpress/data', () => ( {
+	useDispatch: () => ( { insertBlock: mockInsertBlock } ),
+	useSelect: ( fn ) =>
+		fn( () => ( {
+			getBlockInsertionPoint: () => mockInsertionPoint,
+		} ) ),
+} ) );
+
+jest.mock( '@wordpress/block-editor', () => ( {
+	store: { name: 'core/block-editor' },
+} ) );
+
+jest.mock( '@wordpress/element', () => {
+	const React = require( 'react' );
+	return {
+		useState: React.useState,
+		useEffect: React.useEffect,
+		useCallback: React.useCallback,
+		useMemo: React.useMemo,
+		useRef: React.useRef,
+		createElement: React.createElement,
+		Fragment: React.Fragment,
+	};
+} );
+
+jest.mock( '@wordpress/i18n', () => ( {
+	__: ( s ) => s,
+	sprintf: ( fmt, ...args ) => {
+		let i = 0;
+		return fmt.replace( /%[sd]/g, () => args[ i++ ] );
+	},
+} ) );
+
+jest.mock( '@wordpress/blocks', () => ( {
+	createBlock: ( name, attributes = {} ) => ( {
+		name,
+		attributes,
+		clientId: `test-${ Math.random().toString( 36 ).slice( 2, 9 ) }`,
+		innerBlocks: [],
+	} ),
+} ) );
+
+jest.mock( '@wordpress/components', () => {
+	const React = require( 'react' );
+	return {
+		Button: ( { children, onClick, className, variant, ...rest } ) =>
+			React.createElement(
+				'button',
+				{ onClick, className, ...rest },
+				children
+			),
+		Spinner: () =>
+			React.createElement( 'span', { className: 'spinner' } ),
+	};
+} );
+
+const React = require( 'react' );
+const { createRoot } = require( 'react-dom/client' );
+const { act } = React;
+const ConnectedScrapedMediaPanel =
+	require( '../../src/components/ConnectedScrapedMediaPanel' ).default;
+
+describe( 'ConnectedScrapedMediaPanel — issue #126 cursor position', () => {
+	let container;
+	let root;
+
+	beforeEach( () => {
+		mockInsertBlock.mockClear();
+		mockInsertionPoint = { rootClientId: undefined, index: undefined };
+		container = document.createElement( 'div' );
+		document.body.appendChild( container );
+	} );
+
+	afterEach( async () => {
+		if ( root ) {
+			await act( async () => {
+				root.unmount();
+			} );
+			root = null;
+		}
+		container.remove();
+	} );
+
+	function renderPanel( embeds = [], images = [] ) {
+		return act( async () => {
+			root = createRoot( container );
+			root.render(
+				React.createElement( ConnectedScrapedMediaPanel, {
+					images,
+					embeds,
+					sourceUrl: '',
+				} )
+			);
+		} );
+	}
+
+	test( 'inserts an embed at the cursor index, not at the end', async () => {
+		// Cursor sits after block at index 0 → insertion point index is 1.
+		mockInsertionPoint = { rootClientId: undefined, index: 1 };
+
+		await renderPanel( [
+			'https://www.youtube.com/watch?v=dQw4w9WgXcQ',
+		] );
+
+		const embedButton = container.querySelector(
+			'.press-this-scraped-media__embed-button'
+		);
+		expect( embedButton ).not.toBeNull();
+
+		await act( async () => {
+			embedButton.click();
+		} );
+
+		expect( mockInsertBlock ).toHaveBeenCalledTimes( 1 );
+
+		const [ block, index, rootClientId ] = mockInsertBlock.mock.calls[ 0 ];
+		expect( block.name ).toBe( 'core/embed' );
+		expect( block.attributes.url ).toBe(
+			'https://www.youtube.com/watch?v=dQw4w9WgXcQ'
+		);
+		// THE BUG (#126): without the fix, insertBlock is called with only
+		// the block argument (index/rootClientId undefined) so the reducer
+		// falls back to appending at the end. The fix passes the cursor's
+		// index from getBlockInsertionPoint().
+		expect( index ).toBe( 1 );
+		expect( rootClientId ).toBeUndefined();
+	} );
+
+	test( 'inside a nested rootClientId, passes that rootClientId through', async () => {
+		mockInsertionPoint = { rootClientId: 'parent-id', index: 2 };
+
+		await renderPanel( [
+			'https://www.youtube.com/watch?v=dQw4w9WgXcQ',
+		] );
+
+		const embedButton = container.querySelector(
+			'.press-this-scraped-media__embed-button'
+		);
+
+		await act( async () => {
+			embedButton.click();
+		} );
+
+		const [ , index, rootClientId ] = mockInsertBlock.mock.calls[ 0 ];
+		expect( index ).toBe( 2 );
+		expect( rootClientId ).toBe( 'parent-id' );
+	} );
+
+	test( 'inserting an image also goes to the cursor index', async () => {
+		mockInsertionPoint = { rootClientId: undefined, index: 1 };
+
+		// ScrapedMediaPanel filters images by dimensions; stub Image so each
+		// image passes the size threshold immediately.
+		const OriginalImage = global.Image;
+		global.Image = class {
+			constructor() {
+				setTimeout( () => {
+					this.width = 1024;
+					this.height = 1024;
+					if ( this.onload ) {
+						this.onload();
+					}
+				}, 0 );
+			}
+		};
+
+		try {
+			await renderPanel( [], [ 'https://example.com/img.jpg' ] );
+
+			// Wait for the dimension-filter setTimeout to fire.
+			await act( async () => {
+				await new Promise( ( resolve ) => setTimeout( resolve, 5 ) );
+			} );
+
+			const imageButton = container.querySelector(
+				'.press-this-scraped-media__image-button'
+			);
+			expect( imageButton ).not.toBeNull();
+
+			await act( async () => {
+				imageButton.click();
+			} );
+
+			expect( mockInsertBlock ).toHaveBeenCalledTimes( 1 );
+			const [ block, index ] = mockInsertBlock.mock.calls[ 0 ];
+			expect( block.name ).toBe( 'core/image' );
+			expect( index ).toBe( 1 );
+		} finally {
+			global.Image = OriginalImage;
+		}
+	} );
+} );

--- a/tests/components/scraped-media-insertion.test.js
+++ b/tests/components/scraped-media-insertion.test.js
@@ -36,12 +36,12 @@ describe( 'Scraped media insertion respects cursor position', () => {
 		);
 	} );
 
-	test( 'ConnectedScrapedMediaPanel imports useDispatch and useSelect from @wordpress/data', () => {
+	test( 'ConnectedScrapedMediaPanel imports useDispatch and useRegistry from @wordpress/data', () => {
 		expect( connectedSource ).toMatch(
 			/import\s*\{[^}]*useDispatch[^}]*\}\s*from\s*['"]@wordpress\/data['"]/
 		);
 		expect( connectedSource ).toMatch(
-			/import\s*\{[^}]*useSelect[^}]*\}\s*from\s*['"]@wordpress\/data['"]/
+			/import\s*\{[^}]*useRegistry[^}]*\}\s*from\s*['"]@wordpress\/data['"]/
 		);
 	} );
 

--- a/tests/components/scraped-media-insertion.test.js
+++ b/tests/components/scraped-media-insertion.test.js
@@ -1,11 +1,13 @@
 /**
- * Scraped Media Insertion Tests
+ * Scraped Media Insertion — structural tests.
  *
  * Verifies that inserting scraped media (images/embeds) from the sidebar
- * uses the block editor store's insertBlock action, which respects cursor
- * position, rather than manually appending to the blocks array.
+ * uses the block editor store's insertBlock action, with the cursor's
+ * insertion point passed in so blocks land at the cursor — not appended at
+ * the end. See connected-scraped-media-panel.test.js for behavior tests.
  *
- * Regression test for https://github.com/WordPress/press-this/issues/76
+ * Original regression: https://github.com/WordPress/press-this/issues/76
+ * Cursor-position regression: https://github.com/WordPress/press-this/issues/126
  *
  * @package press-this
  */
@@ -14,49 +16,58 @@ const fs = require( 'fs' );
 const path = require( 'path' );
 
 describe( 'Scraped media insertion respects cursor position', () => {
-	let editorContent;
+	let connectedSource;
+	let editorSource;
 
 	beforeAll( () => {
-		const editorPath = path.resolve(
-			__dirname,
-			'../../src/components/PressThisEditor.js'
+		connectedSource = fs.readFileSync(
+			path.resolve(
+				__dirname,
+				'../../src/components/ConnectedScrapedMediaPanel.js'
+			),
+			'utf8'
 		);
-		editorContent = fs.readFileSync( editorPath, 'utf8' );
+		editorSource = fs.readFileSync(
+			path.resolve(
+				__dirname,
+				'../../src/components/PressThisEditor.js'
+			),
+			'utf8'
+		);
 	} );
 
-	test( 'useDispatch is imported from @wordpress/data', () => {
-		expect( editorContent ).toMatch(
+	test( 'ConnectedScrapedMediaPanel imports useDispatch and useSelect from @wordpress/data', () => {
+		expect( connectedSource ).toMatch(
 			/import\s*\{[^}]*useDispatch[^}]*\}\s*from\s*['"]@wordpress\/data['"]/
+		);
+		expect( connectedSource ).toMatch(
+			/import\s*\{[^}]*useSelect[^}]*\}\s*from\s*['"]@wordpress\/data['"]/
 		);
 	} );
 
 	test( 'ConnectedScrapedMediaPanel dispatches insertBlock via blockEditorStore', () => {
-		// The store dispatch must happen inside a child component rendered
-		// within BlockEditorProvider, not in PressThisEditor itself.
-		expect( editorContent ).toMatch(
-			/function\s+ConnectedScrapedMediaPanel/
-		);
-		expect( editorContent ).toMatch(
+		expect( connectedSource ).toMatch(
 			/const\s+\{\s*insertBlock\s*\}\s*=\s*useDispatch\(\s*blockEditorStore\s*\)/
 		);
 	} );
 
-	test( 'ConnectedScrapedMediaPanel is used inside BlockEditorProvider JSX', () => {
-		// The connected wrapper should appear in the rendered JSX.
-		expect( editorContent ).toMatch( /<ConnectedScrapedMediaPanel/ );
-
-		// The raw ScrapedMediaPanel should NOT be rendered directly with
-		// a manual onInsertBlock in the main component's JSX.
-		expect( editorContent ).not.toMatch(
-			/<ScrapedMediaPanel[\s\S]*?onInsertBlock=\{[^}]*setBlocks/
+	test( 'ConnectedScrapedMediaPanel reads getBlockInsertionPoint and passes index + rootClientId', () => {
+		expect( connectedSource ).toMatch( /getBlockInsertionPoint/ );
+		// The insertBlock call must include the cursor's index/rootClientId.
+		expect( connectedSource ).toMatch(
+			/insertBlock\(\s*block\s*,[\s\S]*?index[\s\S]*?rootClientId/
 		);
 	} );
 
-	test( 'no manual array-append insertion pattern exists', () => {
-		// The old bug: setBlocks( ( prev ) => [ ...prev, block ] ) for insertion.
-		// This pattern should not appear tied to an insertBlock callback.
-		expect( editorContent ).not.toMatch(
-			/insertBlock[\s\S]*?setBlocks\s*\(\s*\(\s*prev\s*\)\s*=>\s*\[\s*\.\.\.prev\s*,\s*block\s*\]/
+	test( 'PressThisEditor renders ConnectedScrapedMediaPanel inside its BlockEditorProvider', () => {
+		expect( editorSource ).toMatch(
+			/import\s+ConnectedScrapedMediaPanel\s+from\s+['"]\.\/ConnectedScrapedMediaPanel['"]/
+		);
+		expect( editorSource ).toMatch( /<ConnectedScrapedMediaPanel/ );
+
+		// Must NOT manually append blocks via setBlocks( prev => [ ...prev, block ] ).
+		expect( editorSource ).not.toMatch(
+			/onInsertBlock=\{[\s\S]*?setBlocks\s*\(\s*\(\s*prev\s*\)\s*=>\s*\[\s*\.\.\.prev\s*,\s*block\s*\]/
 		);
 	} );
 } );


### PR DESCRIPTION
## Summary

Clicking an embed or image in the Scraped Media sidebar always appended the new block at the end of the document, regardless of cursor position. With this fix the block lands where the cursor is.

## Root cause

`ConnectedScrapedMediaPanel` dispatched `insertBlock(block)` with no index argument. The block-editor `INSERT_BLOCKS` reducer falls back to the end of the block list when `index` is `undefined`, so the new block was always appended. PR #76 had moved insertion onto the store action but didn't pass the cursor's position through.

## Fix

Read the live insertion point via `getBlockInsertionPoint()` and pass `index` + `rootClientId` to `insertBlock`. Same selector full Gutenberg uses for its own inserter.

Extracts the connected wrapper into its own file (`src/components/ConnectedScrapedMediaPanel.js`) so it can be unit-tested without mounting the whole editor.

## Test plan

- [x] New behavior tests in `tests/components/connected-scraped-media-panel.test.js` — three scenarios: cursor mid-document, nested rootClientId, image insertion path. All three failed against the old code (index was `undefined`); all pass after the fix.
- [x] Updated structural tests in `tests/components/scraped-media-insertion.test.js` to assert the connected panel reads `getBlockInsertionPoint`.
- [x] Full unit suite (`npm run test:unit`) — 357/357 pass.
- [x] `npm run lint` clean.
- [x] `npm run build` succeeds.
- [ ] Manual: open Press This, click into the middle of an existing paragraph, click a Scraped Media embed → block lands at cursor.

Fixes #126