### PR TITLE
Bump wp-env to 11.x and use --auto-port

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -143,7 +143,7 @@ jobs:
         run: npm run build
 
       - name: Start wp-env
-        run: npx wp-env start
+        run: npm run env:start
 
       - name: Create test users
         run: npx wp-env run cli wp user create subscriber subscriber@example.com --role=subscriber --user_pass=password

--- a/package-lock.json
+++ b/package-lock.json
@@ -30,7 +30,7 @@
       },
       "devDependencies": {
         "@playwright/test": "^1.58.2",
-        "@wordpress/env": "^10.37.0",
+        "@wordpress/env": "^11.5.0",
         "@wordpress/scripts": "^31.2.0",
         "terser": "^5.44.1"
       },
@@ -9928,14 +9928,14 @@
       }
     },
     "node_modules/@wordpress/env": {
-      "version": "10.39.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/env/-/env-10.39.0.tgz",
-      "integrity": "sha512-Hgl2RQAAzXFMqkpegGWT1/KkX88OVikRroPidWkij1WtU8p+AZniTcncWmlWqbdLdfGbPqQS5ZkqDZCzrQjgnA==",
+      "version": "11.5.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/env/-/env-11.5.0.tgz",
+      "integrity": "sha512-JWtSqja0yGa5F2LM5OwFnc0d1nXRXQt6TdGne+jBU5gcRfxj4+c/Sn+fheBFDBU0xLkTsefeJqJSafQZ66F1UA==",
       "dev": true,
       "license": "GPL-2.0-or-later",
       "dependencies": {
         "@inquirer/prompts": "^7.2.0",
-        "@wp-playground/cli": "^3.0.0",
+        "@wp-playground/cli": "^3.0.48",
         "chalk": "^4.0.0",
         "copy-dir": "^1.3.0",
         "cross-spawn": "^7.0.6",
@@ -9946,7 +9946,6 @@
         "ora": "^4.0.2",
         "rimraf": "^5.0.10",
         "simple-git": "^3.5.0",
-        "terminal-link": "^2.0.0",
         "yargs": "^17.3.0"
       },
       "bin": {
@@ -28159,37 +28158,6 @@
         "node": ">=18.13.0"
       }
     },
-    "node_modules/terminal-link": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/terminal-link/-/terminal-link-2.1.1.tgz",
-      "integrity": "sha512-un0FmiRUQNr5PJqy9kP7c40F5BOfpGlYTrxonDChEZB7pzZxRNp/bt+ymiy9/npwXya9KH99nJ/GXFIiUkYGFQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "ansi-escapes": "^4.2.1",
-        "supports-hyperlinks": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=8"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/terminal-link/node_modules/supports-hyperlinks": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/supports-hyperlinks/-/supports-hyperlinks-2.3.0.tgz",
-      "integrity": "sha512-RpsAZlpWcDwOPQA22aCH4J0t7L8JmAvsCxfOSEwm7cQs3LshN36QaTkwd70DnBOXDWGssw2eUoc8CaRWT0XunA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "has-flag": "^4.0.0",
-        "supports-color": "^7.0.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
     "node_modules/terser": {
       "version": "5.46.1",
       "resolved": "https://registry.npmjs.org/terser/-/terser-5.46.1.tgz",
@@ -28841,7 +28809,7 @@
       "version": "5.9.3",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
-      "devOptional": true,
+      "dev": true,
       "license": "Apache-2.0",
       "peer": true,
       "bin": {

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "test:unit": "wp-scripts test-unit-js --testPathIgnorePatterns='/worktrees/'",
     "test:js": "wp-scripts test-unit-js --testPathPattern='tests/'",
     "wp-env": "wp-env",
-    "env:start": "wp-env start",
+    "env:start": "wp-env start --auto-port",
     "env:stop": "wp-env stop",
     "env:destroy": "wp-env destroy",
     "env:cli": "wp-env run cli",
@@ -36,7 +36,7 @@
   },
   "devDependencies": {
     "@playwright/test": "^1.58.2",
-    "@wordpress/env": "^10.37.0",
+    "@wordpress/env": "^11.5.0",
     "@wordpress/scripts": "^31.2.0",
     "terser": "^5.44.1"
   },

--- a/playwright.config.js
+++ b/playwright.config.js
@@ -2,11 +2,15 @@
  * Playwright configuration for Press This E2E tests.
  *
  * The wp-env dev environment can land on any port when started with
- * `--auto-port` (and 8888 is busy). Resolve the live URL from
+ * `--auto-port` (and 8888 is busy). Resolve the live port from
  * `wp-env status --json` so tests follow wp-env wherever it lands. Order:
  * 1. PRESS_THIS_BASE_URL env var (explicit override).
- * 2. `wp-env status --json` urls.development (auto-detect).
+ * 2. `wp-env status --json` ports.development (auto-detect).
  * 3. http://localhost:8888 (fallback for fresh checkouts before env starts).
+ *
+ * Reads `ports.development` rather than `urls.development` because the
+ * latter comes from WP_SITEURL config and can be stale when --auto-port
+ * reassigns ports.
  *
  * @see https://playwright.dev/docs/test-configuration
  */
@@ -26,8 +30,9 @@ function resolveBaseUrl() {
 		);
 		if ( result.status === 0 && result.stdout ) {
 			const status = JSON.parse( result.stdout );
-			if ( status?.status === 'running' && status.urls?.development ) {
-				return status.urls.development;
+			const port = status?.ports?.development;
+			if ( status?.status === 'running' && port ) {
+				return `http://localhost:${ port }`;
 			}
 		}
 	} catch {

--- a/playwright.config.js
+++ b/playwright.config.js
@@ -17,29 +17,63 @@
 const { defineConfig } = require( '@playwright/test' );
 const { spawnSync } = require( 'child_process' );
 
+const DEFAULT_BASE_URL = 'http://localhost:8888';
+
+function warnFallback( reason ) {
+	// Surface why we fell back so a contributor whose env is on a non-default
+	// port doesn't silently run tests against the wrong service.
+	// eslint-disable-next-line no-console
+	console.warn(
+		`[playwright] could not resolve wp-env port (${ reason }); ` +
+			`falling back to ${ DEFAULT_BASE_URL }. ` +
+			'Set PRESS_THIS_BASE_URL to override.'
+	);
+}
+
 function resolveBaseUrl() {
 	if ( process.env.PRESS_THIS_BASE_URL ) {
 		return process.env.PRESS_THIS_BASE_URL;
 	}
 
+	let result;
 	try {
-		const result = spawnSync(
-			'npx',
-			[ 'wp-env', 'status', '--json' ],
-			{ encoding: 'utf8', timeout: 10000 }
-		);
-		if ( result.status === 0 && result.stdout ) {
-			const status = JSON.parse( result.stdout );
-			const port = status?.ports?.development;
-			if ( status?.status === 'running' && port ) {
-				return `http://localhost:${ port }`;
-			}
-		}
-	} catch {
-		// Fall through to default below.
+		result = spawnSync( 'npx', [ 'wp-env', 'status', '--json' ], {
+			encoding: 'utf8',
+			timeout: 10000,
+		} );
+	} catch ( error ) {
+		warnFallback( `wp-env spawn threw: ${ error.message }` );
+		return DEFAULT_BASE_URL;
 	}
 
-	return 'http://localhost:8888';
+	if ( result.error ) {
+		// Includes ETIMEDOUT from the spawn timeout above.
+		warnFallback( `wp-env error: ${ result.error.message }` );
+		return DEFAULT_BASE_URL;
+	}
+
+	if ( result.status !== 0 || ! result.stdout ) {
+		warnFallback( `wp-env status exited ${ result.status }` );
+		return DEFAULT_BASE_URL;
+	}
+
+	let status;
+	try {
+		status = JSON.parse( result.stdout );
+	} catch ( error ) {
+		warnFallback( `wp-env JSON parse failed: ${ error.message }` );
+		return DEFAULT_BASE_URL;
+	}
+
+	const port = status?.ports?.development;
+	if ( status?.status !== 'running' || ! port ) {
+		warnFallback(
+			`wp-env reported status="${ status?.status }" port=${ port }`
+		);
+		return DEFAULT_BASE_URL;
+	}
+
+	return `http://localhost:${ port }`;
 }
 
 module.exports = defineConfig( {

--- a/playwright.config.js
+++ b/playwright.config.js
@@ -1,9 +1,41 @@
 /**
  * Playwright configuration for Press This E2E tests.
  *
+ * The wp-env dev environment can land on any port when started with
+ * `--auto-port` (and 8888 is busy). Resolve the live URL from
+ * `wp-env status --json` so tests follow wp-env wherever it lands. Order:
+ * 1. PRESS_THIS_BASE_URL env var (explicit override).
+ * 2. `wp-env status --json` urls.development (auto-detect).
+ * 3. http://localhost:8888 (fallback for fresh checkouts before env starts).
+ *
  * @see https://playwright.dev/docs/test-configuration
  */
 const { defineConfig } = require( '@playwright/test' );
+const { spawnSync } = require( 'child_process' );
+
+function resolveBaseUrl() {
+	if ( process.env.PRESS_THIS_BASE_URL ) {
+		return process.env.PRESS_THIS_BASE_URL;
+	}
+
+	try {
+		const result = spawnSync(
+			'npx',
+			[ 'wp-env', 'status', '--json' ],
+			{ encoding: 'utf8', timeout: 10000 }
+		);
+		if ( result.status === 0 && result.stdout ) {
+			const status = JSON.parse( result.stdout );
+			if ( status?.status === 'running' && status.urls?.development ) {
+				return status.urls.development;
+			}
+		}
+	} catch {
+		// Fall through to default below.
+	}
+
+	return 'http://localhost:8888';
+}
 
 module.exports = defineConfig( {
 	testDir: './tests/e2e',
@@ -13,7 +45,7 @@ module.exports = defineConfig( {
 	workers: 1,
 	reporter: 'list',
 	use: {
-		baseURL: 'http://localhost:8888',
+		baseURL: resolveBaseUrl(),
 		screenshot: 'only-on-failure',
 		trace: 'on-first-retry',
 	},


### PR DESCRIPTION
## Summary

Stop hard-failing on port 8888 conflicts. `wp-env start --auto-port` (added in wp-env 11.0) tries 8888 first and falls back to the next available port if it's busy. Useful when a contributor already has another local dev environment (Jetpack, a different wp-env, etc.) on 8888.

## What changed

- Bump `@wordpress/env` from 10.x to 11.x in `package.json` / lockfile.
- `npm run env:start` now passes `--auto-port`. Existing contributors don't have to do anything different — if 8888 is free, behavior is unchanged.
- `playwright.config.js` resolves `baseURL` dynamically by shelling out to `wp-env status --json`, so e2e tests follow wp-env wherever it lands. Order of resolution:
  1. `PRESS_THIS_BASE_URL` env var (explicit override).
  2. `ports.development` from `wp-env status --json` (auto-detect).
  3. `http://localhost:8888` (fallback for fresh checkouts before env starts).

  We use `ports.development` rather than `urls.development` because the latter is read from `WP_SITEURL` config and is stale when `--auto-port` reassigns the port mid-flight.

## wp-env 11 breaking changes worth knowing about

The wp-env 11 [release notes](https://github.com/WordPress/gutenberg/blob/trunk/packages/env/CHANGELOG.md) flag two changes that could matter here:

- **Pretty permalinks are the default now** (was plain). Press This's `getWpRestBaseUrl()` already handles both pretty (`/wp-json/`) and plain (`?rest_route=`) formats, so no code change required.
- **`port` config defaults to `null`** (was 8888). With Playwright now reading the live port, this is fine — we're no longer relying on the default value matching anywhere.

## Test plan

- [x] `npm install` resolves `@wordpress/env@^11.5.0` and `wp-env start --help` shows `--auto-port`.
- [x] `npm run lint` clean.
- [x] `npm run test:unit` — 352/352 pass.
- [x] **End-to-end verification with port 8888 occupied:** ran nginx in Docker on 8888, then `npm run env:start`. wp-env landed on 8889/8890 instead of failing. `npm run test:e2e tests/e2e/auth-access.spec.js` (4 tests) passed end-to-end against the auto-ported env, confirming Playwright's resolver follows wp-env correctly.