### PR TITLE
Bump version to 2.1.0-beta

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "press-this",
-  "version": "2.0.2",
+  "version": "2.1.0-beta",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "press-this",
-      "version": "2.0.2",
+      "version": "2.1.0-beta",
       "license": "GPL-2.0+",
       "dependencies": {
         "@wordpress/a11y": "^4.40.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "press-this",
-  "version": "2.0.2",
+  "version": "2.1.0-beta",
   "description": "A little tool that lets you grab bits of the web and create new posts with ease.",
   "repository": {
     "type": "git",

--- a/press-this-plugin.php
+++ b/press-this-plugin.php
@@ -5,7 +5,7 @@
  * Plugin Name: Press This
  * Plugin URI:  https://wordpress.org
  * Description: A little tool that lets you grab bits of the web and create new posts with ease. Now powered by the Gutenberg block editor.
- * Version:     2.0.2
+ * Version:     2.1.0-beta
  * Author:      WordPress Contributors
  * Author URI:  https://wordpress.org
  * License:     GPL-2.0+
@@ -34,7 +34,7 @@
  * @since 1.0.0
  * @since 2.0.1 Updated for Gutenberg block editor integration.
  */
-define( 'PRESS_THIS__VERSION', '2.0.2' );
+define( 'PRESS_THIS__VERSION', '2.1.0-beta' );
 
 /**
  * Minimum WordPress version required for the Gutenberg features.


### PR DESCRIPTION
## Summary

First beta cut for 2.1.0. Bumps the version in the three files that move on every release:

- \`press-this-plugin.php\` — \`Version:\` header and \`PRESS_THIS__VERSION\` constant
- \`package.json\`
- \`package-lock.json\`

\`Stable tag\` in \`readme.txt\` intentionally **not** changed — it stays at \`2.0.2\` until the final \`2.1.0\` cut, so wordpress.org keeps serving the current stable.

## What 2.1.0 contains so far

User-visible changes since 2.0.2 (full changelog will be written for the stable cut):

**New**
- Mobile web app support / Add to Home Screen (#91)
- Post scheduling (#89)

**Fix**
- Cursor jumping to position 0 after closing the link popover with Escape (#118)
- Scraped Media insertion respects cursor position (#128)
- YouTube/Vimeo embed previews not showing in the editor; embed provider matching is now host-anchored to avoid lookalike-URL false positives (#129)
- Bookmarklet on mobile browsers (#100)
- Category/tag panels now check taxonomy registration before showing (#112)

**Infra (not user-visible)**
- wp-env 11.x with \`--auto-port\` (#130), grunt removal (#117), Node 22 LTS (#103), CI merge-queue support (#114), several dep bumps.

## Test plan

- [x] \`npm run lint\` clean
- [ ] CI green on this PR
- [ ] After merge: tag \`2.1.0-beta\` on GitHub → \`release.yml\` builds the zip → distribute for testing