### PR TITLE
Bump GitHub Actions to Node 24-compatible majors

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,10 +16,10 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version-file: '.nvmrc'
           cache: 'npm'
@@ -51,7 +51,7 @@ jobs:
 
       - name: Upload release asset
         if: github.event_name == 'release'
-        uses: softprops/action-gh-release@v1
+        uses: softprops/action-gh-release@v3
         with:
           files: press-this.zip
         env:
@@ -59,7 +59,7 @@ jobs:
 
       - name: Upload artifact (for manual runs)
         if: github.event_name == 'workflow_dispatch'
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: press-this-plugin
           path: dist/

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,10 +14,10 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version-file: '.nvmrc'
           cache: 'npm'
@@ -44,7 +44,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
@@ -58,7 +58,7 @@ jobs:
         run: echo "dir=$(composer config cache-files-dir)" >> $GITHUB_OUTPUT
 
       - name: Cache Composer dependencies
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: ${{ steps.composer-cache.outputs.dir }}
           key: ${{ runner.os }}-composer-${{ hashFiles('**/composer.json') }}
@@ -76,10 +76,10 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version-file: '.nvmrc'
           cache: 'npm'
@@ -109,10 +109,10 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version-file: '.nvmrc'
           cache: 'npm'
@@ -126,7 +126,7 @@ jobs:
 
       - name: Cache Playwright browsers
         id: playwright-cache
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: ~/.cache/ms-playwright
           key: ${{ runner.os }}-playwright-${{ steps.playwright-version.outputs.version }}
@@ -153,7 +153,7 @@ jobs:
 
       - name: Upload test artifacts
         if: failure()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: playwright-report
           path: |


### PR DESCRIPTION
## Summary

GitHub is deprecating Node.js 20 on the Actions runners. The build for the Release workflow surfaced this warning yesterday:

> Node.js 20 actions are deprecated. The following actions are running on Node.js 20 and may not work as expected: actions/checkout v4, actions/setup-node v4, softprops/action-gh-release v1. Actions will be forced to run with Node.js 24 by default starting June 2nd, 2026. Node.js 20 will be removed from the runner on September 16th, 2026.

This is a soft deprecation today — workflows still run — but on June 2 GitHub will force-bump JS actions to Node 24 regardless. Bumping to majors that natively target Node 24 means the runtime our actions were authored against matches what they'll execute on.

## Changes

| Action | Before | After | Notes |
| --- | --- | --- | --- |
| `actions/checkout` | v4 | v6 | v5+ moved runtime to Node 24 |
| `actions/setup-node` | v4 | v6 | v6 limits automatic caching to npm; we already pass `cache: 'npm'` so no-op for us |
| `actions/cache` | v4 | v5 | runtime to Node 24 |
| `actions/upload-artifact` | v4 | v7 | runtime to Node 24 |
| `softprops/action-gh-release` | v1 | v3 | v3 release notes explicitly: "moves the action runtime from Node 20 to Node 24" |

`shivammathur/setup-php` v2 was not flagged by the deprecation warning and has no newer floating major; left at v2.

## Test plan

- [ ] CI green on this PR (covers checkout, setup-node, cache, upload-artifact in the Tests workflow)
- [ ] Release workflow path validated when the next tag is cut — that's the only path that exercises `action-gh-release` v3