### PR TITLE
fix: bookmarklet postMessage rejected by origin check

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -253,7 +253,12 @@ export default function App() {
 		}
 
 		async function handleMessage( event ) {
-			if ( event.origin !== window.location.origin ) {
+			// The bookmarklet runs on whatever third-party page the user is
+			// on, so its postMessage origin will never match our own. Gate
+			// on the message source instead — only the window that opened
+			// this popup (the bookmarklet's window) may deliver scraped
+			// data. Other windows posting to us are ignored.
+			if ( ! window.opener || event.source !== window.opener ) {
 				return;
 			}
 

--- a/tests/components/app-postmessage.test.js
+++ b/tests/components/app-postmessage.test.js
@@ -37,7 +37,9 @@ jest.mock( '@wordpress/i18n', () => ( {
 jest.mock( '../../src/components/Header', () => () => null );
 jest.mock( '../../src/components/PressThisEditor', () => () => null );
 
-// Keep the real utils module shape but avoid HTML parser side effects.
+// processScrapedData only calls buildSuggestedContentFromMetadata from this
+// module — stub it so we don't pull in the HTML parser graph just to assert
+// the message handler ran.
 jest.mock( '../../src/utils', () => ( {
 	buildSuggestedContentFromMetadata: () => '<p>stub content</p>',
 } ) );
@@ -51,6 +53,7 @@ describe( 'App — bookmarklet postMessage handler (issue #135)', () => {
 	let container;
 	let root;
 	let originalFetch;
+	let openerFrame;
 
 	beforeEach( () => {
 		container = document.createElement( 'div' );
@@ -64,14 +67,16 @@ describe( 'App — bookmarklet postMessage handler (issue #135)', () => {
 			} )
 		);
 
-		// The bookmarklet opens this popup via window.open(), so the popup
-		// always has a window.opener pointing at the bookmarklet's window.
-		// Use `window` itself as a stand-in opener — what matters for the
-		// handler is identity, not what the reference is.
+		// In production, window.opener is a *distinct* Window object — the
+		// bookmarklet's page. Mount an iframe and use its contentWindow as
+		// the opener so the identity check runs against a real foreign
+		// Window, not the popup's own window.
+		openerFrame = document.createElement( 'iframe' );
+		document.body.appendChild( openerFrame );
 		Object.defineProperty( window, 'opener', {
 			configurable: true,
 			writable: true,
-			value: window,
+			value: openerFrame.contentWindow,
 		} );
 
 		window.pressThisData = {
@@ -100,6 +105,8 @@ describe( 'App — bookmarklet postMessage handler (issue #135)', () => {
 			root = null;
 		}
 		container.remove();
+		openerFrame?.remove();
+		openerFrame = null;
 		global.fetch = originalFetch;
 		Object.defineProperty( window, 'opener', {
 			configurable: true,

--- a/tests/components/app-postmessage.test.js
+++ b/tests/components/app-postmessage.test.js
@@ -1,0 +1,202 @@
+/**
+ * App — bookmarklet postMessage handler.
+ *
+ * Reproduces https://github.com/WordPress/press-this/issues/135:
+ * the bookmarklet runs on a third-party page (any origin) and posts scraped
+ * data to the Press This popup. The handler must accept these cross-origin
+ * messages while still rejecting spoofed messages from other windows. Validate
+ * by source identity (event.source === window.opener), not by origin equality.
+ *
+ * @package press-this
+ */
+
+globalThis.IS_REACT_ACT_ENVIRONMENT = true;
+
+jest.mock( '@wordpress/element', () => {
+	const React = require( 'react' );
+	return {
+		useState: React.useState,
+		useEffect: React.useEffect,
+		useCallback: React.useCallback,
+		useMemo: React.useMemo,
+		useRef: React.useRef,
+		createElement: React.createElement,
+		Fragment: React.Fragment,
+	};
+} );
+
+jest.mock( '@wordpress/i18n', () => ( {
+	__: ( s ) => s,
+	sprintf: ( fmt, ...args ) => {
+		let i = 0;
+		return fmt.replace( /%[sd]/g, () => args[ i++ ] );
+	},
+} ) );
+
+// Heavy children — stub so App renders without pulling the editor stack.
+jest.mock( '../../src/components/Header', () => () => null );
+jest.mock( '../../src/components/PressThisEditor', () => () => null );
+
+// Keep the real utils module shape but avoid HTML parser side effects.
+jest.mock( '../../src/utils', () => ( {
+	buildSuggestedContentFromMetadata: () => '<p>stub content</p>',
+} ) );
+
+const React = require( 'react' );
+const { createRoot } = require( 'react-dom/client' );
+const { act } = React;
+const App = require( '../../src/App' ).default;
+
+describe( 'App — bookmarklet postMessage handler (issue #135)', () => {
+	let container;
+	let root;
+	let originalFetch;
+
+	beforeEach( () => {
+		container = document.createElement( 'div' );
+		document.body.appendChild( container );
+
+		originalFetch = global.fetch;
+		global.fetch = jest.fn( () =>
+			Promise.resolve( {
+				ok: true,
+				json: () => Promise.resolve( { embeds: [] } ),
+			} )
+		);
+
+		// The bookmarklet opens this popup via window.open(), so the popup
+		// always has a window.opener pointing at the bookmarklet's window.
+		// Use `window` itself as a stand-in opener — what matters for the
+		// handler is identity, not what the reference is.
+		Object.defineProperty( window, 'opener', {
+			configurable: true,
+			writable: true,
+			value: window,
+		} );
+
+		window.pressThisData = {
+			postMessageMode: true,
+			restUrl: 'http://example.test/wp-json/press-this/v1/',
+			restNonce: 'test-nonce',
+			sourceUrl: '',
+			images: [],
+			embeds: [],
+			allowedBlocks: [],
+			postId: 1,
+			title: '',
+			content: '',
+			postStatus: 'draft',
+			postDate: '',
+			siteName: 'Test',
+			siteUrl: 'http://example.test/',
+		};
+	} );
+
+	afterEach( async () => {
+		if ( root ) {
+			await act( async () => {
+				root.unmount();
+			} );
+			root = null;
+		}
+		container.remove();
+		global.fetch = originalFetch;
+		Object.defineProperty( window, 'opener', {
+			configurable: true,
+			writable: true,
+			value: null,
+		} );
+		delete window.pressThisData;
+	} );
+
+	async function mountApp() {
+		await act( async () => {
+			root = createRoot( container );
+			root.render( React.createElement( App ) );
+		} );
+	}
+
+	async function dispatchAndFlush( event ) {
+		await act( async () => {
+			window.dispatchEvent( event );
+			// Let the validateEmbeds fetch + state updates settle.
+			await Promise.resolve();
+			await Promise.resolve();
+		} );
+	}
+
+	test( 'accepts postMessage from cross-origin opener (the bookmarklet path)', async () => {
+		await mountApp();
+
+		// The bookmarklet runs on whatever site the user is browsing, so the
+		// message origin will not match the popup's origin. Before the fix
+		// this message is silently dropped and no scraped data ever reaches
+		// the editor.
+		await dispatchAndFlush(
+			new MessageEvent( 'message', {
+				origin: 'https://ma.tt',
+				source: window.opener,
+				data: {
+					type: 'press-this-data',
+					version: 11,
+					data: {
+						t: 'Test title',
+						u: 'https://ma.tt/post/',
+						_embeds: [
+							'https://www.youtube.com/watch?v=dQw4w9WgXcQ',
+						],
+					},
+				},
+			} )
+		);
+
+		// processScrapedData fires validateEmbeds, which POSTs to the REST
+		// endpoint. If the message was rejected, fetch would not be called.
+		expect( global.fetch ).toHaveBeenCalledWith(
+			'http://example.test/wp-json/press-this/v1/validate-embeds',
+			expect.objectContaining( { method: 'POST' } )
+		);
+	} );
+
+	test( 'rejects postMessage from a non-opener source (spoofing protection)', async () => {
+		await mountApp();
+
+		// A message that arrives from some other window — not the one that
+		// opened this popup — must be ignored even though the data shape
+		// looks legitimate. An iframe gives us a separate Window object
+		// distinct from window.opener.
+		const iframe = document.createElement( 'iframe' );
+		document.body.appendChild( iframe );
+		const fakeSource = iframe.contentWindow;
+
+		await dispatchAndFlush(
+			new MessageEvent( 'message', {
+				origin: 'https://attacker.example',
+				source: fakeSource,
+				data: {
+					type: 'press-this-data',
+					version: 11,
+					data: { t: 'Spoofed' },
+				},
+			} )
+		);
+
+		iframe.remove();
+
+		expect( global.fetch ).not.toHaveBeenCalled();
+	} );
+
+	test( 'ignores messages with the wrong type from the opener', async () => {
+		await mountApp();
+
+		await dispatchAndFlush(
+			new MessageEvent( 'message', {
+				origin: 'https://ma.tt',
+				source: window.opener,
+				data: { type: 'something-else', data: { t: 'nope' } },
+			} )
+		);
+
+		expect( global.fetch ).not.toHaveBeenCalled();
+	} );
+} );

--- a/tests/e2e/html-selection.spec.js
+++ b/tests/e2e/html-selection.spec.js
@@ -60,6 +60,19 @@ async function loadEditor( page ) {
 	await page
 		.locator( '.press-this-editor__content' )
 		.waitFor( { timeout: 10000 } );
+
+	// The handler accepts only messages whose source is window.opener (the
+	// bookmarklet's window). These tests skip the popup mechanics and post
+	// from the page itself, so make the page its own opener — event.source
+	// will then equal window.opener and the handler runs.
+	await page.evaluate( () => {
+		if ( ! window.opener ) {
+			Object.defineProperty( window, 'opener', {
+				value: window,
+				configurable: true,
+			} );
+		}
+	} );
 }
 
 const editorContent = '.press-this-editor__content';


### PR DESCRIPTION
## Summary

Fixes #135. The bookmarklet's `postMessage` to the Press This popup was silently dropped, leaving the editor empty (no title, no content, no media, no selection) whenever the bookmarklet was the source of data — i.e. the normal flow.

## Root cause

`src/App.js`'s message handler required the message origin to equal the popup's own origin:

```js
if ( event.origin !== window.location.origin ) {
    return;
}
```

The bookmarklet runs on whatever third-party page the user is on (`ma.tt`, `youtube.com`, …), so `event.origin` is *always* cross-origin to the WordPress site. Every legitimate bookmarklet message was rejected.

The check came in as a hardening pass in PR #100 (commit `a55f050`, "Add event.origin check on the postMessage listener"). The intent was right (don't let arbitrary pages forge `press-this-data` messages); the implementation was wrong for this transport.

The bug landed in trunk on Apr 3, after the 2.0.2 release on Mar 25. Stable users on 2.0.2 are unaffected — this only impacts trunk and 2.1.0-beta.

## Fix

Validate the message **source** instead of its origin:

```js
if ( ! window.opener || event.source !== window.opener ) {
    return;
}
```

Only the window that opened this popup (the bookmarklet's window) holds a `Window` reference to it via `window.open()`, so identity-checking against `window.opener` keeps the spoofing protection without rejecting cross-origin senders.

## Tests

Added `tests/components/app-postmessage.test.js` with three cases that mount `<App />` with stubbed children and dispatch `MessageEvent`s:

1. Cross-origin opener with valid `press-this-data` payload → handler runs (asserted via the `validate-embeds` fetch firing). **This test fails on trunk and passes after the fix** — exactly the regression to guard against.
2. Non-opener source (separate iframe `Window`) with otherwise-valid payload → rejected. Locks in spoofing protection so a future change can't drop the source check.
3. Opener with the wrong `event.data.type` → rejected.

## Test plan

- [x] `npm run test:unit` — all 364 tests pass
- [x] `npm run lint` — clean
- [ ] Manual: install on a test site, run the bookmarklet on a third-party page (ma.tt, a YouTube watch URL, etc.), confirm scraped title/selection/media populate the editor.
- [ ] Manual: confirm `pm=1` URL still works when proxy is enabled (the auto-scan path is independent and was working).
- [ ] Manual: confirm the `wn=1` window.name fallback (popup-blocked / mobile) is unaffected — it doesn't go through the postMessage handler.