### PR TITLE
Bump version to 2.1.0-beta2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "press-this",
-  "version": "2.1.0-beta",
+  "version": "2.1.0-beta2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "press-this",
-      "version": "2.1.0-beta",
+      "version": "2.1.0-beta2",
       "license": "GPL-2.0+",
       "dependencies": {
         "@wordpress/a11y": "^4.40.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "press-this",
-  "version": "2.1.0-beta",
+  "version": "2.1.0-beta2",
   "description": "A little tool that lets you grab bits of the web and create new posts with ease.",
   "repository": {
     "type": "git",

--- a/press-this-plugin.php
+++ b/press-this-plugin.php
@@ -5,7 +5,7 @@
  * Plugin Name: Press This
  * Plugin URI:  https://wordpress.org
  * Description: A little tool that lets you grab bits of the web and create new posts with ease. Now powered by the Gutenberg block editor.
- * Version:     2.1.0-beta
+ * Version:     2.1.0-beta2
  * Author:      WordPress Contributors
  * Author URI:  https://wordpress.org
  * License:     GPL-2.0+
@@ -34,7 +34,7 @@
  * @since 1.0.0
  * @since 2.0.1 Updated for Gutenberg block editor integration.
  */
-define( 'PRESS_THIS__VERSION', '2.1.0-beta' );
+define( 'PRESS_THIS__VERSION', '2.1.0-beta2' );
 
 /**
  * Minimum WordPress version required for the Gutenberg features.


### PR DESCRIPTION
## Summary

Second beta cut for 2.1.0. Bumps the version in the three files that move on every release:

- `press-this-plugin.php` — `Version:` header and `PRESS_THIS__VERSION` constant
- `package.json`
- `package-lock.json`

`Stable tag` in `readme.txt` intentionally **not** changed — it stays at `2.0.2` until the final `2.1.0` cut, so wordpress.org keeps serving the current stable.

## What changed since 2.1.0-beta

- Fix: bookmarklet postMessage rejected by overly strict origin check (PR 136, fixes issue 135)
- CI: bump GitHub Actions to Node 24-compatible majors (PR 134)
- Deps: bump ip-address from 10.1.0 to 10.2.0 (PR 137)

## Test plan

- [x] `npm run lint` clean
- [ ] CI green on this PR
- [ ] After merge: tag `2.1.0-beta2` on GitHub → `release.yml` builds the zip → distribute for testing