### PR TITLE
Release 2.1.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "press-this",
-  "version": "2.1.0-beta2",
+  "version": "2.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "press-this",
-      "version": "2.1.0-beta2",
+      "version": "2.1.0",
       "license": "GPL-2.0+",
       "dependencies": {
         "@wordpress/a11y": "^4.40.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "press-this",
-  "version": "2.1.0-beta2",
+  "version": "2.1.0",
   "description": "A little tool that lets you grab bits of the web and create new posts with ease.",
   "repository": {
     "type": "git",

--- a/press-this-plugin.php
+++ b/press-this-plugin.php
@@ -5,7 +5,7 @@
  * Plugin Name: Press This
  * Plugin URI:  https://wordpress.org
  * Description: A little tool that lets you grab bits of the web and create new posts with ease. Now powered by the Gutenberg block editor.
- * Version:     2.1.0-beta2
+ * Version:     2.1.0
  * Author:      WordPress Contributors
  * Author URI:  https://wordpress.org
  * License:     GPL-2.0+
@@ -34,7 +34,7 @@
  * @since 1.0.0
  * @since 2.0.1 Updated for Gutenberg block editor integration.
  */
-define( 'PRESS_THIS__VERSION', '2.1.0-beta2' );
+define( 'PRESS_THIS__VERSION', '2.1.0' );
 
 /**
  * Minimum WordPress version required for the Gutenberg features.

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Donate link: http://wordpressfoundation.org/donate/
 Tags: post, quick-post, photo-post, bookmarklet, gutenberg
 Requires at least: 6.9
 Tested up to: 7.0
-Stable tag: 2.0.2
+Stable tag: 2.1.0
 Requires PHP: 7.4
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
@@ -124,6 +124,9 @@ All existing hooks continue to work:
 
 == Upgrade Notice ==
 
+= 2.1.0 =
+Post scheduling, mobile home-screen support, and fixes for embed previews and cursor placement.
+
 = 2.0.2 =
 Bug fixes, new keyboard shortcuts, and undo/redo support.
 
@@ -137,6 +140,17 @@ Fixes styling issues and bumps tested version.
 Restores bookmarklet functionality.
 
 == Changelog ==
+
+= 2.1.0 =
+* **New:** Schedule posts for future publishing directly from Press This
+* **New:** Mobile web app support — add Press This to your home screen for an app-like experience
+* **Fix:** YouTube and Vimeo embed previews not rendering in the editor
+* **Fix:** Scraped media embeds now insert at the cursor position instead of the end of the post
+* **Fix:** Cursor jumping to the start of the post after closing the link popover with Escape
+* **Fix:** Bookmarklet failing on some mobile browsers
+* **Fix:** Bookmarklet content rejected by an overly strict postMessage origin check
+* **Fix:** Category and tag panels no longer appear for post types without those taxonomies registered
+* **Dev:** Build tooling modernized — Grunt removed, Node 22/24 support, wp-env 11, merge queue CI
 
 = 2.0.2 =
 * **New:** Undo/redo support in the block editor (Ctrl+Z / Ctrl+Shift+Z)


### PR DESCRIPTION
Promotes `2.1.0-beta2` to the stable **2.1.0** release.

## Changes
- Bump version to `2.1.0` in `press-this-plugin.php` (plugin header + `PRESS_THIS__VERSION`), `package.json`, and `package-lock.json`.
- Update `Stable tag` to `2.1.0` in `readme.txt` (this is what wordpress.org serves to all users).
- Add the `2.1.0` changelog section and upgrade notice.

## Changelog (2.1.0)
Everything merged to trunk since the 2.0.2 release:

- **New:** Schedule posts for future publishing (#89)
- **New:** Mobile web app / Add to Home Screen support (#91)
- **Fix:** YouTube and Vimeo embed previews not rendering in the editor (#129)
- **Fix:** Scraped media embeds insert at the cursor position instead of end of post (#128)
- **Fix:** Cursor jumping to start of post after closing the link popover with Escape (#118)
- **Fix:** Bookmarklet failing on some mobile browsers (#100)
- **Fix:** Bookmarklet content rejected by an overly strict postMessage origin check (#136)
- **Fix:** Category/tag panels no longer appear for post types without those taxonomies registered (#112)
- **Dev:** Build tooling modernized — Grunt removed, Node 22/24 support, wp-env 11, merge queue CI

## Notes
- No functional code changes — version/metadata only.
- After merge: tag `2.1.0`, cut the GitHub release (triggers the ZIP build), branch `branch/2.1`, and deploy to wordpress.org via SVN (manual — there is no deploy automation).