### PR TITLE
fix: repair legacy embed className via WP-CLI

### DIFF
--- a/includes/class-press-this-cli-commands.php
+++ b/includes/class-press-this-cli-commands.php
@@ -1,0 +1,120 @@
+<?php
+/**
+ * Press This CLI Commands
+ *
+ * @package Press_This_Plugin
+ * @since 2.1.1
+ */
+
+/**
+ * WP-CLI commands for Press This.
+ *
+ * @since 2.1.1
+ */
+class Press_This_CLI_Commands {
+
+	/**
+	 * Repair core/embed blocks saved before the className fix in #129.
+	 *
+	 * Finds posts whose content has a core/embed block with a `<figure>`
+	 * className missing the `wp-block-embed-{provider}` class that
+	 * Gutenberg's save() output requires, and rewrites the content to
+	 * add it.
+	 *
+	 * ## OPTIONS
+	 *
+	 * [--dry-run]
+	 * : Report the posts that would be changed, without saving.
+	 *
+	 * [--post-type=<post-type>]
+	 * : Limit the scan to a specific post type. Default: post,page.
+	 *
+	 * ## EXAMPLES
+	 *
+	 *     wp press-this repair-embeds --dry-run
+	 *     wp press-this repair-embeds
+	 *     wp press-this repair-embeds --post-type=post
+	 *
+	 * @since 2.1.1
+	 *
+	 * @param array $args       Positional arguments (unused).
+	 * @param array $assoc_args Associative arguments.
+	 */
+	public function repair_embeds( $args, $assoc_args ) { // phpcs:ignore Generic.CodeAnalysis.UnusedFunctionParameter.Found -- Required by WP-CLI command signature.
+		require_once __DIR__ . '/class-press-this-embed-repair.php';
+
+		$dry_run    = WP_CLI\Utils\get_flag_value( $assoc_args, 'dry-run', false );
+		$post_type  = WP_CLI\Utils\get_flag_value( $assoc_args, 'post-type', 'post,page' );
+		$post_types = array_map( 'trim', explode( ',', $post_type ) );
+
+		$repaired_count = 0;
+		$scanned_count  = 0;
+		$batch_size     = 100;
+		$last_id        = 0;
+
+		global $wpdb;
+
+		do {
+			// Query post_content directly with a LIKE match instead of WP_Query's
+			// 's' param, which also searches the title and can be altered by
+			// other plugins hooking the search (relevance sorting, stopwords).
+			$post_ids = $wpdb->get_col(
+				$wpdb->prepare(
+					"SELECT ID FROM {$wpdb->posts} WHERE ID > %d AND post_type IN (" . implode( ',', array_fill( 0, count( $post_types ), '%s' ) ) . ') AND post_content LIKE %s ORDER BY ID ASC LIMIT %d', // phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared -- $wpdb->posts is a table name, not user input.
+					array_merge( array( $last_id ), $post_types, array( '%wp:embed%', $batch_size ) )
+				)
+			);
+
+			$batch_count = count( $post_ids );
+
+			foreach ( $post_ids as $post_id ) {
+				$post_id = (int) $post_id;
+				++$scanned_count;
+				$last_id = max( $last_id, $post_id );
+
+				$post = get_post( $post_id );
+
+				if ( ! $post || ! has_block( 'core/embed', $post ) ) {
+					continue;
+				}
+
+				$repaired_content = Press_This_Embed_Repair::repair_content( $post->post_content );
+
+				if ( false === $repaired_content ) {
+					continue;
+				}
+
+				if ( $dry_run ) {
+					++$repaired_count;
+					WP_CLI::log( sprintf( 'Would repair post %d: %s', $post_id, get_the_title( $post_id ) ) );
+					continue;
+				}
+
+				$updated = wp_update_post(
+					array(
+						'ID'           => $post_id,
+						'post_content' => wp_slash( $repaired_content ),
+					),
+					true
+				);
+
+				if ( is_wp_error( $updated ) ) {
+					WP_CLI::warning( sprintf( 'Failed to repair post %d: %s', $post_id, $updated->get_error_message() ) );
+					continue;
+				}
+
+				++$repaired_count;
+				WP_CLI::log( sprintf( 'Repaired post %d: %s', $post_id, get_the_title( $post_id ) ) );
+			}
+		} while ( $batch_count === $batch_size );
+
+		WP_CLI::success(
+			sprintf(
+				/* translators: 1: number of posts repaired or that would be repaired, 2: number of posts scanned. */
+				$dry_run ? '%1$d post(s) would be repaired out of %2$d scanned.' : '%1$d post(s) repaired out of %2$d scanned.',
+				$repaired_count,
+				$scanned_count
+			)
+		);
+	}
+}

--- a/includes/class-press-this-embed-repair.php
+++ b/includes/class-press-this-embed-repair.php
@@ -1,0 +1,123 @@
+<?php
+/**
+ * Press This Embed Repair
+ *
+ * Repairs core/embed blocks saved before the className fix in #129, where the
+ * figure element is missing the wp-block-embed-{provider} class that core/embed's
+ * save() output requires for block validation to pass.
+ *
+ * @package Press_This_Plugin
+ * @since 2.1.1
+ */
+
+/**
+ * Press This embed repair class.
+ *
+ * @since 2.1.1
+ */
+class Press_This_Embed_Repair {
+
+	/**
+	 * Repair legacy core/embed blocks in post content.
+	 *
+	 * @since 2.1.1
+	 *
+	 * @param string $content Post content.
+	 * @return string|false Repaired content, or false if nothing needed fixing.
+	 */
+	public static function repair_content( $content ) {
+		if ( false === strpos( $content, 'wp:embed' ) ) {
+			return false;
+		}
+
+		$repaired = false;
+		$blocks   = self::repair_blocks( parse_blocks( $content ), $repaired );
+
+		if ( ! $repaired ) {
+			return false;
+		}
+
+		return serialize_blocks( $blocks );
+	}
+
+	/**
+	 * Recursively walk parsed blocks and repair core/embed blocks in place.
+	 *
+	 * @since 2.1.1
+	 *
+	 * @param array $blocks   Parsed blocks.
+	 * @param bool  $repaired Set true by reference when any block is changed.
+	 * @return array Blocks, with embeds repaired where needed.
+	 */
+	private static function repair_blocks( array $blocks, &$repaired ) {
+		foreach ( $blocks as $index => $block ) {
+			if ( 'core/embed' === $block['blockName'] ) {
+				$fixed = self::fix_embed_block( $block );
+
+				if ( false !== $fixed ) {
+					$blocks[ $index ] = $fixed;
+					$repaired         = true;
+				}
+			}
+
+			if ( ! empty( $block['innerBlocks'] ) ) {
+				$blocks[ $index ]['innerBlocks'] = self::repair_blocks( $block['innerBlocks'], $repaired );
+			}
+		}
+
+		return $blocks;
+	}
+
+	/**
+	 * Add the missing wp-block-embed-{provider} class to a single embed block.
+	 *
+	 * @since 2.1.1
+	 *
+	 * @param array $block Parsed core/embed block.
+	 * @return array|false Repaired block, or false if it did not need fixing.
+	 */
+	private static function fix_embed_block( array $block ) {
+		$provider = isset( $block['attrs']['providerNameSlug'] ) ? $block['attrs']['providerNameSlug'] : '';
+
+		// The className mismatch only exists for blocks with both type and
+		// providerNameSlug set -- e.g. the generic embed shape produced by
+		// get_suggested_content() has neither and is already self-consistent.
+		if ( empty( $provider ) || empty( $block['attrs']['type'] ) ) {
+			return false;
+		}
+
+		// providerNameSlug comes from stored post content, not a trusted source.
+		// Reject anything that isn't a plain CSS class token before it goes near HTML.
+		if ( ! is_string( $provider ) || sanitize_html_class( $provider ) !== $provider ) {
+			return false;
+		}
+
+		// Matches double-quoted class attributes only, which is what save() always
+		// emits. A hand-edited single-quoted class would just be left alone.
+		if ( ! preg_match( '/<figure\b[^>]*\sclass="([^"]*)"/', $block['innerHTML'], $matches, PREG_OFFSET_CAPTURE ) ) {
+			return false;
+		}
+
+		$wanted_class     = 'wp-block-embed-' . $provider;
+		$existing_classes = preg_split( '/\s+/', trim( $matches[1][0] ) );
+
+		if ( in_array( $wanted_class, $existing_classes, true ) ) {
+			return false;
+		}
+
+		// core/embed has no innerBlocks, so innerContent should be a single chunk
+		// identical to innerHTML. Bail instead of guessing at a riskier rewrite
+		// if that assumption doesn't hold for some other reason.
+		if ( count( $block['innerContent'] ) !== 1 || $block['innerContent'][0] !== $block['innerHTML'] ) {
+			return false;
+		}
+
+		$class_end = $matches[1][1] + strlen( $matches[1][0] );
+		$new_html  = substr( $block['innerHTML'], 0, $class_end ) . ' ' . $wanted_class . substr( $block['innerHTML'], $class_end );
+
+		$block['innerHTML']    = $new_html;
+		$block['innerContent'] = array( $new_html );
+
+		return $block;
+	}
+}

--- a/press-this-plugin.php
+++ b/press-this-plugin.php
@@ -98,6 +98,12 @@ add_action( 'tool_box', 'press_this_tool_box' );
 // Load text domain for translations.
 add_action( 'init', 'press_this_load_textdomain' );
 
+// Register WP-CLI commands.
+if ( defined( 'WP_CLI' ) && WP_CLI ) {
+	require_once __DIR__ . '/includes/class-press-this-cli-commands.php';
+	WP_CLI::add_command( 'press-this', 'Press_This_CLI_Commands' );
+}
+
 /**
  * Load plugin text domain for translations.
  *
@@ -397,7 +403,7 @@ function press_this_rest_save_post( $request ) {
 			$post_data['post_date_gmt'] = get_gmt_from_date( $post_data['post_date'] );
 			$post_data['post_status']   = 'future';
 			// Required: wp_update_post ignores post_date changes unless edit_date is true.
-			$post_data['edit_date']     = true;
+			$post_data['edit_date'] = true;
 		} else {
 			$post_data['post_status'] = 'pending';
 		}

--- a/tests/php/test-embed-repair.php
+++ b/tests/php/test-embed-repair.php
@@ -1,0 +1,186 @@
+<?php
+/**
+ * Tests for legacy embed className repair.
+ *
+ * @package Press_This_Plugin
+ */
+
+use WorDBless\BaseTestCase;
+
+/**
+ * Test case for Press_This_Embed_Repair.
+ */
+class Test_Embed_Repair extends BaseTestCase {
+
+	/**
+	 * Set up before each test.
+	 */
+	public function set_up() {
+		parent::set_up();
+
+		require_once dirname( dirname( __DIR__ ) ) . '/includes/class-press-this-embed-repair.php';
+	}
+
+	/**
+	 * Test 1: Adds the missing wp-block-embed-{provider} class.
+	 */
+	public function test_adds_missing_provider_class() {
+		$content = '<!-- wp:embed {"url":"https://www.youtube.com/watch?v=abc","type":"video","providerNameSlug":"youtube"} -->
+<figure class="wp-block-embed is-type-video is-provider-youtube"><div class="wp-block-embed__wrapper">
+https://www.youtube.com/watch?v=abc
+</div></figure>
+<!-- /wp:embed -->';
+
+		$repaired = Press_This_Embed_Repair::repair_content( $content );
+
+		$this->assertNotFalse( $repaired );
+		$this->assertStringContainsString( 'wp-block-embed-youtube', $repaired );
+		$this->assertStringContainsString( 'is-provider-youtube', $repaired );
+	}
+
+	/**
+	 * Test 2: Already-correct content is left untouched (idempotent).
+	 */
+	public function test_correct_content_is_untouched() {
+		$content = '<!-- wp:embed {"url":"https://www.youtube.com/watch?v=abc","type":"video","providerNameSlug":"youtube"} -->
+<figure class="wp-block-embed is-type-video is-provider-youtube wp-block-embed-youtube"><div class="wp-block-embed__wrapper">
+https://www.youtube.com/watch?v=abc
+</div></figure>
+<!-- /wp:embed -->';
+
+		$repaired = Press_This_Embed_Repair::repair_content( $content );
+
+		$this->assertFalse( $repaired );
+	}
+
+	/**
+	 * Test 3: Repairing twice does not double-append the class.
+	 */
+	public function test_repair_is_idempotent() {
+		$content = '<!-- wp:embed {"url":"https://www.youtube.com/watch?v=abc","type":"video","providerNameSlug":"youtube"} -->
+<figure class="wp-block-embed is-type-video is-provider-youtube"><div class="wp-block-embed__wrapper">
+https://www.youtube.com/watch?v=abc
+</div></figure>
+<!-- /wp:embed -->';
+
+		$once  = Press_This_Embed_Repair::repair_content( $content );
+		$twice = Press_This_Embed_Repair::repair_content( $once );
+
+		$this->assertFalse( $twice );
+		$this->assertSame( 1, substr_count( $once, 'wp-block-embed-youtube' ) );
+	}
+
+	/**
+	 * Test 4: Generic embed blocks without type/providerNameSlug are left alone.
+	 *
+	 * This matches the shape produced by get_suggested_content() for the
+	 * non-JS code path, which is self-consistent and not affected by this bug.
+	 */
+	public function test_generic_embed_without_provider_is_untouched() {
+		$content = '<!-- wp:embed {"url":"https://example.com/video"} -->
+<figure class="wp-block-embed"><div class="wp-block-embed__wrapper">
+https://example.com/video
+</div></figure>
+<!-- /wp:embed -->';
+
+		$repaired = Press_This_Embed_Repair::repair_content( $content );
+
+		$this->assertFalse( $repaired );
+	}
+
+	/**
+	 * Test 5: Multiple embeds in one post are each repaired, exactly once,
+	 * on their own figure -- not leaked onto the paragraph in between.
+	 */
+	public function test_multiple_embeds_are_all_repaired() {
+		$content = '<!-- wp:embed {"url":"https://www.youtube.com/watch?v=abc","type":"video","providerNameSlug":"youtube"} -->
+<figure class="wp-block-embed is-type-video is-provider-youtube"><div class="wp-block-embed__wrapper">
+https://www.youtube.com/watch?v=abc
+</div></figure>
+<!-- /wp:embed -->
+
+<!-- wp:paragraph -->
+<p>Some text in between.</p>
+<!-- /wp:paragraph -->
+
+<!-- wp:embed {"url":"https://vimeo.com/12345","type":"video","providerNameSlug":"vimeo"} -->
+<figure class="wp-block-embed is-type-video is-provider-vimeo"><div class="wp-block-embed__wrapper">
+https://vimeo.com/12345
+</div></figure>
+<!-- /wp:embed -->';
+
+		$repaired = Press_This_Embed_Repair::repair_content( $content );
+
+		$this->assertNotFalse( $repaired );
+
+		$named_blocks = array_values( array_filter( parse_blocks( $repaired ), fn( $b ) => null !== $b['blockName'] ) );
+
+		$this->assertSame( 'core/embed', $named_blocks[0]['blockName'] );
+		$this->assertSame( 1, substr_count( $named_blocks[0]['innerHTML'], 'wp-block-embed-youtube' ) );
+		$this->assertStringNotContainsString( 'wp-block-embed-vimeo', $named_blocks[0]['innerHTML'] );
+
+		$this->assertSame( 'core/paragraph', $named_blocks[1]['blockName'] );
+		$this->assertStringNotContainsString( 'wp-block-embed-', $named_blocks[1]['innerHTML'] );
+
+		$this->assertSame( 'core/embed', $named_blocks[2]['blockName'] );
+		$this->assertSame( 1, substr_count( $named_blocks[2]['innerHTML'], 'wp-block-embed-vimeo' ) );
+		$this->assertStringNotContainsString( 'wp-block-embed-youtube', $named_blocks[2]['innerHTML'] );
+	}
+
+	/**
+	 * Test 6: A nested embed block (inside a group) is repaired, and the
+	 * class lands on the embed's own figure, not the group's wrapper div.
+	 */
+	public function test_nested_embed_in_group_is_repaired() {
+		$content = '<!-- wp:group -->
+<div class="wp-block-group">
+<!-- wp:embed {"url":"https://www.youtube.com/watch?v=abc","type":"video","providerNameSlug":"youtube"} -->
+<figure class="wp-block-embed is-type-video is-provider-youtube"><div class="wp-block-embed__wrapper">
+https://www.youtube.com/watch?v=abc
+</div></figure>
+<!-- /wp:embed -->
+</div>
+<!-- /wp:group -->';
+
+		$repaired = Press_This_Embed_Repair::repair_content( $content );
+
+		$this->assertNotFalse( $repaired );
+
+		$blocks       = parse_blocks( $repaired );
+		$embed_block  = $blocks[0]['innerBlocks'][0];
+
+		$this->assertSame( 'core/embed', $embed_block['blockName'] );
+		$this->assertSame( 1, substr_count( $embed_block['innerHTML'], 'wp-block-embed-youtube' ) );
+		$this->assertStringNotContainsString( 'wp-block-embed-youtube', $blocks[0]['innerContent'][0] );
+	}
+
+	/**
+	 * Test 7: Content with no embed blocks at all returns false quickly.
+	 */
+	public function test_content_without_embeds_returns_false() {
+		$content = '<!-- wp:paragraph -->
+<p>Just a paragraph, no embeds here.</p>
+<!-- /wp:paragraph -->';
+
+		$repaired = Press_This_Embed_Repair::repair_content( $content );
+
+		$this->assertFalse( $repaired );
+	}
+
+	/**
+	 * Test 8: A providerNameSlug that isn't a plain class token is rejected
+	 * instead of being inserted into the HTML. providerNameSlug comes from
+	 * stored post content, so it must not be trusted as a safe class name.
+	 */
+	public function test_malicious_provider_slug_is_rejected() {
+		$content = '<!-- wp:embed {"url":"https://www.youtube.com/watch?v=abc","type":"video","providerNameSlug":"youtube\" onclick=\"alert(1)"} -->
+<figure class="wp-block-embed is-type-video"><div class="wp-block-embed__wrapper">
+https://www.youtube.com/watch?v=abc
+</div></figure>
+<!-- /wp:embed -->';
+
+		$repaired = Press_This_Embed_Repair::repair_content( $content );
+
+		$this->assertFalse( $repaired );
+	}
+}


### PR DESCRIPTION
## Summary
Posts saved by Press This before PR #129 have `core/embed` blocks whose `<figure>` className is missing `wp-block-embed-{provider}` (e.g. `wp-block-embed-youtube`). Gutenberg's `save()` output for that block always includes this class when `type`/`providerNameSlug` attrs are set, so the mismatch fails block validation and shows "Block contains unexpected or invalid content" in the standard editor.

Adds a WP-CLI command that finds and repairs this specific mismatch in stored post content.

Fixes #131

## Changes
### includes/class-press-this-embed-repair.php (new)
**Before:**
```php
// no repair mechanism existed
```
**After:**
```php
class Press_This_Embed_Repair {
	public static function repair_content( $content ) {
		// parse_blocks(), find core/embed blocks with type + providerNameSlug
		// but missing wp-block-embed-{provider} in the figure class, append it,
		// serialize_blocks() back. Returns false if nothing needed fixing.
	}
}
```
**Why:** Isolated, pure content-rewrite logic that's easy to unit test without a live WP-CLI environment. Validates `providerNameSlug` against `sanitize_html_class()` before it touches HTML, since that value comes from stored post content, not a trusted source.

### includes/class-press-this-cli-commands.php (new)
**Before:**
```php
// no CLI commands existed in the plugin
```
**After:**
```php
class Press_This_CLI_Commands {
	public function repair_embeds( $args, $assoc_args ) {
		// wp press-this repair-embeds [--dry-run] [--post-type=<type>]
		// batches posts via $wpdb LIKE query on post_content, pre-filters
		// with has_block(), repairs, wp_update_post()s only real changes
	}
}
```
**Why:** Explicit, auditable repair path with dry-run support, rather than silently rewriting content on every page load.

### press-this-plugin.php
**Before:**
```php
add_action( 'init', 'press_this_load_textdomain' );
```
**After:**
```php
add_action( 'init', 'press_this_load_textdomain' );

if ( defined( 'WP_CLI' ) && WP_CLI ) {
	require_once __DIR__ . '/includes/class-press-this-cli-commands.php';
	WP_CLI::add_command( 'press-this', 'Press_This_CLI_Commands' );
}
```
**Why:** Registers the command only in a WP-CLI context, no overhead on regular requests.

## Testing
**Test 1: Legacy embed fails validation before repair**
1. Create a post with `<figure class="wp-block-embed is-type-video is-provider-youtube">` (missing the 4th class)
2. Open it in the standard editor
Result: "Block contains unexpected or invalid content" shown, as reported in the issue

**Test 2: Repair fixes it**
1. Run `wp press-this repair-embeds --dry-run`, confirm it lists the post
2. Run `wp press-this repair-embeds`
3. Reload the post in the standard editor
Result: embed renders normally, no validation warning. Re-running the command reports 0 posts repaired (idempotent).

**Test 3: Unaffected content is left alone**
1. Run the command against a post created after PR #129, or one using the generic embed shape with no `type`/`providerNameSlug` attrs (the PHP `get_suggested_content()` path)
Result: not touched, since neither is broken

Also ran full PHP unit suite (283 tests, all passing) and `composer php:lint` / `composer php:compatibility` clean.