### PR TITLE
Add custom taxonomy support to Press This panel

### DIFF
--- a/class-wp-press-this-plugin.php
+++ b/class-wp-press-this-plugin.php
@@ -161,21 +161,20 @@ class WP_Press_This_Plugin {
 		// Sanitize category IDs with absint and verify capability.
 		$category_tax = get_taxonomy( 'category' );
 		if ( current_user_can( $category_tax->cap->assign_terms ) ) {
-			if ( ! empty( $_POST['post_category'] ) ) {
+			if ( isset( $_POST['post_category'] ) && is_array( $_POST['post_category'] ) ) {
 				// Convert all values to integers and filter out zeros (invalid IDs).
-				$categories                 = array_map( 'absint', (array) $_POST['post_category'] );
-				$categories                 = array_filter( $categories );
-				$post_data['post_category'] = $categories;
+				$categories                 = array_map( 'absint', $_POST['post_category'] );
+				$post_data['post_category'] = array_values( array_filter( $categories ) );
 			} else {
 				$post_data['post_category'] = array();
 			}
 		}
 
 		// Sanitize taxonomy inputs with proper type handling.
-		if ( ! empty( $_POST['tax_input'] ) ) {
+		if ( ! empty( $_POST['tax_input'] ) && is_array( $_POST['tax_input'] ) ) {
 			$tax_input = array();
 
-			foreach ( (array) $_POST['tax_input'] as $tax => $terms ) {
+			foreach ( $_POST['tax_input'] as $tax => $terms ) {
 				// Sanitize taxonomy key.
 				$tax = sanitize_key( $tax );
 
@@ -198,13 +197,16 @@ class WP_Press_This_Plugin {
 				// Sanitize terms based on taxonomy type.
 				if ( is_taxonomy_hierarchical( $tax ) ) {
 					// Hierarchical taxonomies use term IDs (integers).
-					$tax_input[ $tax ] = array_map( 'absint', (array) $terms );
-					$tax_input[ $tax ] = array_filter( $tax_input[ $tax ] );
+					$terms = array_filter( array_map( 'absint', (array) $terms ) );
 				} else {
 					// Non-hierarchical taxonomies use term names (strings).
-					$tax_input[ $tax ] = array_map( 'sanitize_text_field', (array) $terms );
-					$tax_input[ $tax ] = array_filter( $tax_input[ $tax ] );
+					$terms = array_filter( array_map( 'sanitize_text_field', (array) $terms ) );
 				}
+
+				// The client sent this taxonomy, so an empty array means "clear
+				// the terms", not "leave them alone". Only keys absent from the
+				// request are left untouched.
+				$tax_input[ $tax ] = array_values( $terms );
 			}
 
 			if ( ! empty( $tax_input ) ) {
@@ -1509,7 +1511,6 @@ class WP_Press_This_Plugin {
 				'label'        => $taxonomy->labels->name,
 				'hierarchical' => (bool) $taxonomy->hierarchical,
 				'restBase'     => ! empty( $taxonomy->show_in_rest ) ? ( $taxonomy->rest_base ? $taxonomy->rest_base : $taxonomy->name ) : '',
-				'canEditTerms' => current_user_can( $taxonomy->cap->edit_terms ),
 				'terms'        => $terms_data,
 			);
 		}
@@ -1517,13 +1518,83 @@ class WP_Press_This_Plugin {
 		/**
 		 * Filters the custom taxonomies exposed in the Press This panel.
 		 *
+		 * Each entry is validated after the filter runs: an entry that is not
+		 * an array, or whose name, label, restBase, hierarchical, or terms
+		 * fields have the wrong types, is dropped rather than passed to the
+		 * editor as-is.
+		 *
 		 * @since 2.1.1
 		 *
 		 * @param array[] $taxonomies_data List of taxonomy data arrays, each with
-		 *                                 name, label, hierarchical, restBase, canEditTerms, terms.
+		 *                                 name, label, hierarchical, restBase, terms.
 		 * @param string  $post_type       Post type the taxonomies belong to.
 		 */
-		return array_values( apply_filters( 'press_this_taxonomies', $taxonomies_data, $post_type ) );
+		$filtered = apply_filters( 'press_this_taxonomies', $taxonomies_data, $post_type );
+
+		if ( ! is_array( $filtered ) ) {
+			return array();
+		}
+
+		$valid = array();
+
+		foreach ( array_values( $filtered ) as $entry ) {
+			if ( ! is_array( $entry )
+				|| empty( $entry['name'] ) || ! is_string( $entry['name'] )
+				|| ! isset( $entry['label'] ) || ! is_string( $entry['label'] )
+				|| ! isset( $entry['hierarchical'] )
+				|| ( ! is_bool( $entry['hierarchical'] ) && ! is_numeric( $entry['hierarchical'] ) )
+				|| ! isset( $entry['restBase'] ) || ! is_string( $entry['restBase'] )
+				|| ! isset( $entry['terms'] ) || ! is_array( $entry['terms'] )
+			) {
+				continue;
+			}
+
+			$valid[] = array(
+				'name'         => sanitize_key( $entry['name'] ),
+				'label'        => sanitize_text_field( $entry['label'] ),
+				// Booleans pass through; numeric flags are coerced for
+				// filter authors who write 1/0 instead of true/false.
+				'hierarchical' => (bool) $entry['hierarchical'],
+				'restBase'     => sanitize_key( $entry['restBase'] ),
+				'terms'        => $this->sanitize_terms_data( $entry['terms'] ),
+			);
+		}
+
+		return $valid;
+	}
+
+	/**
+	 * Sanitizes the terms list of one filtered taxonomy entry.
+	 *
+	 * Keeps only numeric IDs and string names; drops everything else so a
+	 * malformed term cannot reach the editor markup.
+	 *
+	 * @since 2.1.1
+	 *
+	 * @param mixed $terms Raw terms list from a filter callback.
+	 * @return array[] List of sanitized term arrays with id and name keys.
+	 */
+	private function sanitize_terms_data( $terms ) {
+		$clean = array();
+
+		foreach ( (array) $terms as $term ) {
+			if ( ! is_array( $term )
+				|| ! isset( $term['id'], $term['name'] )
+				|| ! is_numeric( $term['id'] )
+				|| ! is_string( $term['name'] )
+			) {
+				continue;
+			}
+
+			$clean[] = array(
+				'id'     => absint( $term['id'] ),
+				'name'   => sanitize_text_field( $term['name'] ),
+				'parent' => isset( $term['parent'] ) && is_numeric( $term['parent'] ) ? absint( $term['parent'] ) : 0,
+				'slug'   => isset( $term['slug'] ) && is_string( $term['slug'] ) ? sanitize_title( $term['slug'] ) : '',
+			);
+		}
+
+		return $clean;
 	}
 
 	/**

--- a/class-wp-press-this-plugin.php
+++ b/class-wp-press-this-plugin.php
@@ -179,9 +179,14 @@ class WP_Press_This_Plugin {
 				// Sanitize taxonomy key.
 				$tax = sanitize_key( $tax );
 
-				// Validate taxonomy exists.
+				// Validate the taxonomy is registered for this post type.
+				if ( ! is_object_in_taxonomy( $post_type, $tax ) ) {
+					continue;
+				}
+
+				// Validate taxonomy exists and has a UI (matches what's ever exposed to the panel).
 				$tax_object = get_taxonomy( $tax );
-				if ( ! $tax_object ) {
+				if ( ! $tax_object || ! $tax_object->show_ui ) {
 					continue;
 				}
 
@@ -1450,6 +1455,78 @@ class WP_Press_This_Plugin {
 	}
 
 	/**
+	 * Get custom taxonomies registered for a post type, with their terms and capabilities.
+	 *
+	 * Excludes 'category' and 'post_tag', which have their own dedicated panels.
+	 * Only taxonomies with 'show_ui' are included, and only if the current user
+	 * can assign terms.
+	 *
+	 * @since 2.1.1
+	 *
+	 * @param string $post_type Post type to get taxonomies for.
+	 * @return array[] List of taxonomy data arrays.
+	 */
+	private function get_custom_taxonomies_data( $post_type ) {
+		$taxonomies_data = array();
+
+		$taxonomies = get_object_taxonomies( $post_type, 'objects' );
+
+		foreach ( $taxonomies as $taxonomy ) {
+			if ( in_array( $taxonomy->name, array( 'category', 'post_tag' ), true ) ) {
+				continue;
+			}
+
+			if ( ! $taxonomy->show_ui || ! current_user_can( $taxonomy->cap->assign_terms ) ) {
+				continue;
+			}
+
+			$terms_data = array();
+
+			if ( $taxonomy->hierarchical ) {
+				$terms = get_terms(
+					array(
+						'taxonomy'   => $taxonomy->name,
+						'hide_empty' => false,
+						'orderby'    => 'name',
+						'order'      => 'ASC',
+					)
+				);
+
+				if ( ! is_wp_error( $terms ) ) {
+					foreach ( $terms as $term ) {
+						$terms_data[] = array(
+							'id'     => $term->term_id,
+							'name'   => $term->name,
+							'parent' => $term->parent,
+							'slug'   => $term->slug,
+						);
+					}
+				}
+			}
+
+			$taxonomies_data[] = array(
+				'name'         => $taxonomy->name,
+				'label'        => $taxonomy->labels->name,
+				'hierarchical' => (bool) $taxonomy->hierarchical,
+				'restBase'     => ! empty( $taxonomy->show_in_rest ) ? ( $taxonomy->rest_base ? $taxonomy->rest_base : $taxonomy->name ) : '',
+				'canEditTerms' => current_user_can( $taxonomy->cap->edit_terms ),
+				'terms'        => $terms_data,
+			);
+		}
+
+		/**
+		 * Filters the custom taxonomies exposed in the Press This panel.
+		 *
+		 * @since 2.1.1
+		 *
+		 * @param array[] $taxonomies_data List of taxonomy data arrays, each with
+		 *                                 name, label, hierarchical, restBase, canEditTerms, terms.
+		 * @param string  $post_type       Post type the taxonomies belong to.
+		 */
+		return array_values( apply_filters( 'press_this_taxonomies', $taxonomies_data, $post_type ) );
+	}
+
+	/**
 	 * Serves the app's base HTML - minimal shell for React app.
 	 *
 	 * All UI is rendered by React. PHP only provides:
@@ -1528,6 +1605,9 @@ class WP_Press_This_Plugin {
 		$can_assign_cats = $categories_tax && current_user_can( $categories_tax->cap->assign_terms );
 		$can_edit_cats   = $categories_tax && current_user_can( $categories_tax->cap->edit_terms );
 		$can_assign_tags = $tag_tax && current_user_can( $tag_tax->cap->assign_terms );
+
+		// Get custom taxonomies registered for this post type (category/post_tag have their own panels).
+		$custom_taxonomies_data = $this->get_custom_taxonomies_data( $post_type );
 
 		// Get supported post formats.
 		$post_formats = array();
@@ -1619,6 +1699,9 @@ class WP_Press_This_Plugin {
 
 			// Categories data.
 			'categories'          => $categories_data,
+
+			// Custom taxonomies registered for the post type (excludes category/post_tag).
+			'taxonomies'          => $custom_taxonomies_data,
 
 			// Bookmarklet version info.
 			// Only set bookmarkletVersion if we have actual POST data from bookmarklet.

--- a/package-lock.json
+++ b/package-lock.json
@@ -28844,7 +28844,7 @@
       "version": "5.9.3",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
-      "devOptional": true,
+      "dev": true,
       "license": "Apache-2.0",
       "peer": true,
       "bin": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "press-this",
-  "version": "2.1.0",
+  "version": "2.1.1-beta",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "press-this",
-      "version": "2.1.0",
+      "version": "2.1.1-beta",
       "license": "GPL-2.0+",
       "dependencies": {
         "@wordpress/a11y": "^4.40.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "press-this",
-  "version": "2.1.0",
+  "version": "2.1.1-beta",
   "description": "A little tool that lets you grab bits of the web and create new posts with ease.",
   "repository": {
     "type": "git",

--- a/press-this-plugin.php
+++ b/press-this-plugin.php
@@ -5,7 +5,7 @@
  * Plugin Name: Press This
  * Plugin URI:  https://wordpress.org
  * Description: A little tool that lets you grab bits of the web and create new posts with ease. Now powered by the Gutenberg block editor.
- * Version:     2.1.0
+ * Version:     2.1.1-beta
  * Author:      WordPress Contributors
  * Author URI:  https://wordpress.org
  * License:     GPL-2.0+
@@ -34,7 +34,7 @@
  * @since 1.0.0
  * @since 2.0.1 Updated for Gutenberg block editor integration.
  */
-define( 'PRESS_THIS__VERSION', '2.1.0' );
+define( 'PRESS_THIS__VERSION', '2.1.1-beta' );
 
 /**
  * Minimum WordPress version required for the Gutenberg features.
@@ -234,6 +234,10 @@ function press_this_register_rest_routes() {
 					'items'   => array( 'type' => 'string' ),
 					'default' => array(),
 				),
+				'tax_input'      => array(
+					'type'    => 'object',
+					'default' => array(),
+				),
 				'featured_image' => array(
 					'type'              => 'integer',
 					'sanitize_callback' => 'absint',
@@ -355,14 +359,48 @@ function press_this_rest_save_post( $request ) {
 	}
 
 	// Handle tags if user can assign.
-	$tag_tax = get_taxonomy( 'post_tag' );
+	$tag_tax   = get_taxonomy( 'post_tag' );
+	$tax_input = array();
 	if ( current_user_can( $tag_tax->cap->assign_terms ) ) {
 		$tags = $request->get_param( 'tags' );
 		if ( ! empty( $tags ) ) {
-			$post_data['tax_input'] = array(
-				'post_tag' => array_map( 'sanitize_text_field', $tags ),
-			);
+			$tax_input['post_tag'] = array_map( 'sanitize_text_field', $tags );
 		}
+	}
+
+	// Handle custom taxonomies (excludes category/post_tag, which are handled above).
+	$custom_tax_input = $request->get_param( 'tax_input' );
+	if ( ! empty( $custom_tax_input ) && is_array( $custom_tax_input ) ) {
+		foreach ( $custom_tax_input as $tax_name => $terms ) {
+			$tax_name = sanitize_key( $tax_name );
+
+			if ( in_array( $tax_name, array( 'category', 'post_tag' ), true ) ) {
+				continue;
+			}
+
+			if ( ! is_object_in_taxonomy( $post_type, $tax_name ) ) {
+				continue;
+			}
+
+			$tax_object = get_taxonomy( $tax_name );
+			if ( ! $tax_object || ! $tax_object->show_ui || ! current_user_can( $tax_object->cap->assign_terms ) ) {
+				continue;
+			}
+
+			if ( is_taxonomy_hierarchical( $tax_name ) ) {
+				$terms = array_filter( array_map( 'absint', (array) $terms ) );
+			} else {
+				$terms = array_filter( array_map( 'sanitize_text_field', (array) $terms ) );
+			}
+
+			if ( ! empty( $terms ) ) {
+				$tax_input[ $tax_name ] = $terms;
+			}
+		}
+	}
+
+	if ( ! empty( $tax_input ) ) {
+		$post_data['tax_input'] = $tax_input;
 	}
 
 	// Handle publish status.

--- a/press-this-plugin.php
+++ b/press-this-plugin.php
@@ -137,6 +137,7 @@ function wp_ajax_press_this_plugin_add_category() {
  * Register REST API routes for Press This.
  *
  * @since 2.0.1
+ * @since 2.1.1 Added the custom taxonomy save support.
  */
 function press_this_register_rest_routes() {
 	// Web App Manifest for Add to Home Screen / PWA support.
@@ -225,18 +226,27 @@ function press_this_register_rest_routes() {
 					'default'           => '',
 				),
 				'categories'     => array(
-					'type'    => 'array',
-					'items'   => array( 'type' => 'integer' ),
-					'default' => array(),
+					'type'  => 'array',
+					'items' => array( 'type' => 'integer' ),
+					// No default: an absent param must leave the existing
+					// categories alone, while an explicit empty array clears
+					// them. A default of array() would make absent clear too.
 				),
 				'tags'           => array(
-					'type'    => 'array',
-					'items'   => array( 'type' => 'string' ),
-					'default' => array(),
+					'type'  => 'array',
+					'items' => array( 'type' => 'string' ),
 				),
 				'tax_input'      => array(
-					'type'    => 'object',
-					'default' => array(),
+					'type'                 => 'object',
+					// Keys are taxonomy names, values are arrays of term names.
+					// A taxonomy present with an empty array clears its terms;
+					// a taxonomy absent from the object leaves its terms alone.
+					'description'          => __( 'Custom taxonomy terms to assign to the post.', 'press-this' ),
+					'default'              => array(),
+					'additionalProperties' => array(
+						'type'  => 'array',
+						'items' => array( 'type' => 'string' ),
+					),
 				),
 				'featured_image' => array(
 					'type'              => 'integer',
@@ -327,6 +337,7 @@ function press_this_rest_save_permission( $request ) {
  * REST API handler for saving a post from Press This.
  *
  * @since 2.0.1
+ * @since 2.1.1 Added support for saving custom taxonomies.
  *
  * @param WP_REST_Request $request Request object.
  * @return WP_REST_Response|WP_Error Response object on success, WP_Error on failure.
@@ -350,30 +361,38 @@ function press_this_rest_save_post( $request ) {
 	);
 
 	// Handle categories if user can assign.
-	$category_tax = get_taxonomy( 'category' );
-	if ( current_user_can( $category_tax->cap->assign_terms ) ) {
+	$category_tax   = get_taxonomy( 'category' );
+	$set_categories = null;
+	if ( $category_tax && is_object_in_taxonomy( $post_type, 'category' ) && current_user_can( $category_tax->cap->assign_terms ) ) {
 		$categories = $request->get_param( 'categories' );
-		if ( ! empty( $categories ) ) {
-			$post_data['post_category'] = array_map( 'absint', $categories );
+		if ( is_array( $categories ) ) {
+			// The client sent this field, so an empty array means "clear the
+			// categories", not "leave them alone". The route registers no
+			// default, so only a param actually present in the request can
+			// reach this branch.
+			$set_categories = array_values( array_filter( array_map( 'absint', $categories ) ) );
 		}
 	}
 
 	// Handle tags if user can assign.
-	$tag_tax   = get_taxonomy( 'post_tag' );
-	$tax_input = array();
-	if ( current_user_can( $tag_tax->cap->assign_terms ) ) {
+	$tag_tax  = get_taxonomy( 'post_tag' );
+	$set_tags = null;
+	if ( $tag_tax && is_object_in_taxonomy( $post_type, 'post_tag' ) && current_user_can( $tag_tax->cap->assign_terms ) ) {
 		$tags = $request->get_param( 'tags' );
-		if ( ! empty( $tags ) ) {
-			$tax_input['post_tag'] = array_map( 'sanitize_text_field', $tags );
+		if ( is_array( $tags ) ) {
+			// The client sent this field, so an empty array means "clear the
+			// tags", not "leave them alone". No route default is registered,
+			// so only a param actually present in the request gets here.
+			$set_tags = array_values( array_filter( array_map( 'sanitize_text_field', $tags ) ) );
 		}
 	}
 
 	// Handle custom taxonomies (excludes category/post_tag, which are handled above).
 	$custom_tax_input = $request->get_param( 'tax_input' );
+	$set_terms        = array();
 	if ( ! empty( $custom_tax_input ) && is_array( $custom_tax_input ) ) {
 		foreach ( $custom_tax_input as $tax_name => $terms ) {
 			$tax_name = sanitize_key( $tax_name );
-
 			if ( in_array( $tax_name, array( 'category', 'post_tag' ), true ) ) {
 				continue;
 			}
@@ -387,20 +406,15 @@ function press_this_rest_save_post( $request ) {
 				continue;
 			}
 
-			if ( is_taxonomy_hierarchical( $tax_name ) ) {
-				$terms = array_filter( array_map( 'absint', (array) $terms ) );
-			} else {
-				$terms = array_filter( array_map( 'sanitize_text_field', (array) $terms ) );
+			if ( ! is_array( $terms ) ) {
+				continue;
 			}
 
-			if ( ! empty( $terms ) ) {
-				$tax_input[ $tax_name ] = $terms;
-			}
+			// The client sent this taxonomy, so an empty array means "clear the
+			// terms", not "leave them alone". Only keys absent from the request
+			// are left untouched.
+			$set_terms[ $tax_name ] = array_values( $terms );
 		}
-	}
-
-	if ( ! empty( $tax_input ) ) {
-		$post_data['tax_input'] = $tax_input;
 	}
 
 	// Handle publish status.
@@ -435,7 +449,7 @@ function press_this_rest_save_post( $request ) {
 			$post_data['post_date_gmt'] = get_gmt_from_date( $post_data['post_date'] );
 			$post_data['post_status']   = 'future';
 			// Required: wp_update_post ignores post_date changes unless edit_date is true.
-			$post_data['edit_date']     = true;
+			$post_data['edit_date'] = true;
 		} else {
 			$post_data['post_status'] = 'pending';
 		}
@@ -475,6 +489,45 @@ function press_this_rest_save_post( $request ) {
 			__( 'Unable to save the post. Please try again.', 'press-this' ),
 			array( 'status' => 500 )
 		);
+	}
+
+	// Apply term changes directly. wp_update_post() cannot clear terms:
+	// for categories it falls back to the existing terms when the list is
+	// empty (wp-includes/post.php), and for taxonomies it restores existing
+	// terms from an empty tax_input entry. Only call these when the client
+	// actually sent the field; null means "leave untouched".
+	if ( null !== $set_categories ) {
+		$result = wp_set_post_categories( $post_id, $set_categories );
+		if ( is_wp_error( $result ) ) {
+			return new WP_Error(
+				'press_this_term_assignment_failed',
+				__( 'Unable to assign the categories. Please try again.', 'press-this' ),
+				array( 'status' => 500 )
+			);
+		}
+	}
+	if ( null !== $set_tags ) {
+		$result = wp_set_post_tags( $post_id, $set_tags );
+		if ( is_wp_error( $result ) ) {
+			return new WP_Error(
+				'press_this_term_assignment_failed',
+				__( 'Unable to assign the tags. Please try again.', 'press-this' ),
+				array( 'status' => 500 )
+			);
+		}
+	}
+	foreach ( $set_terms as $tax_name => $terms ) {
+		$result = wp_set_post_terms( $post_id, $terms, $tax_name );
+		if ( is_wp_error( $result ) ) {
+			$taxonomy = get_taxonomy( $tax_name );
+			$label    = ( $taxonomy && ! empty( $taxonomy->labels->name ) ) ? strtolower( $taxonomy->labels->name ) : $tax_name;
+			/* translators: %s: taxonomy label. */
+			return new WP_Error(
+				'press_this_term_assignment_failed',
+				sprintf( __( 'Unable to assign the %s terms. Please try again.', 'press-this' ), $label ),
+				array( 'status' => 500 )
+			);
+		}
 	}
 
 	// Set post format.

--- a/readme.txt
+++ b/readme.txt
@@ -36,6 +36,7 @@ Press This 2.0 includes new filters for customization:
 
 * `press_this_allowed_blocks` - Customize which blocks are available in the editor
 * `press_this_post_format_suggestion` - Modify the auto-suggested post format
+* `press_this_taxonomies` - Customize the custom taxonomies shown in the panel
 
 See the [Developer Documentation](#developer-documentation) section below for details.
 
@@ -109,6 +110,21 @@ The `$data` array contains scraped content including:
 - `_embeds` - Array of embed URLs
 - `_meta` - Meta tag data
 - `_jsonld` - JSON-LD structured data
+
+**press_this_taxonomies**
+
+Customize the custom taxonomies shown in the Press This panel. Category and Tags always have their own dedicated panels and are not affected by this filter.
+
+`
+add_filter( 'press_this_taxonomies', function( $taxonomies_data, $post_type ) {
+    // Remove a taxonomy from the panel entirely.
+    return array_values( array_filter( $taxonomies_data, function( $taxonomy ) {
+        return 'my_internal_taxonomy' !== $taxonomy['name'];
+    } ) );
+}, 10, 2 );
+`
+
+Only taxonomies registered for the post type with `show_ui` enabled are included by default, and only if the current user can assign terms for that taxonomy.
 
 = Preserved Hooks from 1.x =
 

--- a/src/App.js
+++ b/src/App.js
@@ -428,6 +428,7 @@ export default function App() {
 					images={ images }
 					embeds={ embeds }
 					categories={ data.categories || [] }
+					taxonomies={ data.taxonomies || [] }
 					postFormats={ data.postFormats || [] }
 					capabilities={ capabilities }
 					restConfig={ restConfig }

--- a/src/components/PressThisEditor.js
+++ b/src/components/PressThisEditor.js
@@ -52,7 +52,8 @@ import LinkEscapeFix from './LinkEscapeFix';
 import ConnectedScrapedMediaPanel from './ConnectedScrapedMediaPanel';
 import FeaturedImagePanel from './FeaturedImagePanel';
 import CategoryPanel from './CategoryPanel';
-import { isStandaloneMode } from '../utils';
+import TaxonomyPanel from './TaxonomyPanel';
+import { isStandaloneMode, getWpRestBaseUrl } from '../utils';
 
 /**
  * Sidebar Block Inspector component.
@@ -191,28 +192,6 @@ function performSafeRedirect( url, inParentWindow = false ) {
 }
 
 /**
- * Build the WordPress REST API base URL for core endpoints.
- *
- * Handles both pretty permalinks (/wp-json/) and index.php?rest_route= formats.
- *
- * @param {string} pressThisRestUrl The Press This REST URL (e.g., /wp-json/press-this/v1/ or index.php?rest_route=/press-this/v1/).
- * @return {string} The base URL for WordPress core REST endpoints.
- */
-function getWpRestBaseUrl( pressThisRestUrl ) {
-	// Check if using index.php?rest_route= format.
-	if ( pressThisRestUrl.includes( 'rest_route=' ) ) {
-		// Extract the base URL up to and including rest_route=.
-		const match = pressThisRestUrl.match( /^(.*[?&]rest_route=)/ );
-		if ( match ) {
-			return match[ 1 ] + '/';
-		}
-	}
-
-	// Pretty permalinks format - replace the namespace.
-	return pressThisRestUrl.replace( /press-this\/v1\/$/, '' );
-}
-
-/**
  * Format a date string for display in the schedule snackbar.
  *
  * Uses the browser's default locale for formatting so the date is displayed
@@ -275,6 +254,7 @@ function formatScheduleDate( dateString, timezone ) {
  * @param {Array}    props.images             Scraped images from source.
  * @param {Array}    props.embeds             Scraped embeds from source.
  * @param {Object}   props.categories         Available categories.
+ * @param {Array}    props.taxonomies         Custom taxonomies registered for the post type.
  * @param {Array}    props.postFormats        Available post formats.
  * @param {Object}   props.capabilities       User capabilities.
  * @param {Object}   props.restConfig         REST API configuration.
@@ -297,6 +277,7 @@ export default function PressThisEditor( {
 	images = [],
 	embeds = [],
 	categories: initialCategories = [],
+	taxonomies = [],
 	postFormats = [],
 	capabilities = {},
 	restConfig = {},
@@ -327,6 +308,9 @@ export default function PressThisEditor( {
 	const [ postFormat, setPostFormat ] = useState( initialFormat );
 	const [ selectedCategories, setSelectedCategories ] = useState( [] );
 	const [ tags, setTags ] = useState( [] );
+	// Custom taxonomy selections, keyed by taxonomy name: term IDs for
+	// hierarchical taxonomies, term names for flat taxonomies.
+	const [ taxonomyTerms, setTaxonomyTerms ] = useState( {} );
 	const [ featuredImageId, setFeaturedImageId ] = useState( 0 );
 	const [ isSaving, setIsSaving ] = useState( false );
 	const [ isReady, setIsReady ] = useState( false );
@@ -541,6 +525,7 @@ export default function PressThisEditor( {
 						format: postFormat,
 						categories: selectedCategories,
 						tags,
+						tax_input: taxonomyTerms,
 						featured_image: featuredImageId,
 						force_redirect: options.forceRedirect || false,
 						date: options.date || '',
@@ -612,6 +597,7 @@ export default function PressThisEditor( {
 			postFormat,
 			selectedCategories,
 			tags,
+			taxonomyTerms,
 			featuredImageId,
 			post.id,
 			restConfig,
@@ -726,6 +712,24 @@ export default function PressThisEditor( {
 	 */
 	const handleTagsChange = useCallback( ( newTags ) => {
 		setTags( newTags );
+	}, [] );
+
+	/**
+	 * Build a selection updater for a single custom taxonomy.
+	 *
+	 * @param {string} taxonomyName Taxonomy name.
+	 * @return {Function} Updater accepting the new value or an updater function.
+	 */
+	const getTaxonomySelectionSetter = useCallback( ( taxonomyName ) => {
+		return ( value ) => {
+			setTaxonomyTerms( ( prev ) => ( {
+				...prev,
+				[ taxonomyName ]:
+					typeof value === 'function'
+						? value( prev[ taxonomyName ] || [] )
+						: value,
+			} ) );
+		};
 	}, [] );
 
 	// Editor settings.
@@ -999,6 +1003,24 @@ export default function PressThisEditor( {
 											) }
 										</PanelBody>
 									) }
+
+									{ /* Custom Taxonomy Panels */ }
+									{ taxonomies.map( ( taxonomy ) => (
+										<TaxonomyPanel
+											key={ taxonomy.name }
+											taxonomy={ taxonomy }
+											selectedTerms={
+												taxonomyTerms[
+													taxonomy.name
+												] || []
+											}
+											onSelectionChange={ getTaxonomySelectionSetter(
+												taxonomy.name
+											) }
+											restUrl={ restConfig.restUrl }
+											restNonce={ restConfig.restNonce }
+										/>
+									) ) }
 								</Panel>
 							</div>
 						</div>

--- a/src/components/TaxonomyPanel.js
+++ b/src/components/TaxonomyPanel.js
@@ -11,7 +11,13 @@
 /**
  * WordPress dependencies
  */
-import { useCallback, useMemo, useRef, useState } from '@wordpress/element';
+import {
+	useCallback,
+	useEffect,
+	useMemo,
+	useRef,
+	useState,
+} from '@wordpress/element';
 import {
 	CheckboxControl,
 	FormTokenField,
@@ -78,7 +84,7 @@ function HierarchicalTaxonomyPanel( {
 	const [ filterValue, setFilterValue ] = useState( '' );
 
 	const termsTree = useMemo(
-		() => buildTermsTree( taxonomy.terms ),
+		() => buildTermsTree( taxonomy.terms || [] ),
 		[ taxonomy.terms ]
 	);
 
@@ -104,7 +110,8 @@ function HierarchicalTaxonomyPanel( {
 	);
 
 	const displayedTerms = filterValue !== '' ? filteredTermsTree : termsTree;
-	const showFilter = taxonomy.terms.length >= MIN_TERMS_COUNT_FOR_FILTER;
+	const showFilter =
+		( taxonomy.terms || [] ).length >= MIN_TERMS_COUNT_FOR_FILTER;
 
 	return (
 		<PanelBody title={ taxonomy.label } initialOpen={ false }>
@@ -157,11 +164,32 @@ function FlatTaxonomyPanel( {
 } ) {
 	const [ suggestions, setSuggestions ] = useState( [] );
 	const searchTimeout = useRef( null );
+	const abortController = useRef( null );
+
+	// PanelBody unmounts its children when collapsed, so this fires on ordinary
+	// use, not just teardown.
+	useEffect( () => {
+		return () => {
+			if ( searchTimeout.current ) {
+				clearTimeout( searchTimeout.current );
+			}
+			if ( abortController.current ) {
+				abortController.current.abort();
+			}
+		};
+	}, [] );
 
 	const searchTerms = useCallback(
 		( search ) => {
 			if ( searchTimeout.current ) {
 				clearTimeout( searchTimeout.current );
+			}
+
+			// clearTimeout only cancels a timer that hasn't fired yet. Once a
+			// request is in flight it has to be aborted, or a slower earlier
+			// response can land last and overwrite newer suggestions.
+			if ( abortController.current ) {
+				abortController.current.abort();
 			}
 
 			if ( ! search || search.length < 2 || ! taxonomy.restBase ) {
@@ -170,30 +198,38 @@ function FlatTaxonomyPanel( {
 			}
 
 			searchTimeout.current = setTimeout( async () => {
+				const controller = new AbortController();
+				abortController.current = controller;
+
 				try {
 					const wpRestBase = getWpRestBaseUrl( restUrl );
-					const taxUrl = wpRestBase.includes( 'rest_route=' )
-						? `${ wpRestBase }wp/v2/${
-								taxonomy.restBase
-						  }&search=${ encodeURIComponent(
-								search
-						  ) }&per_page=10`
-						: `${ wpRestBase }wp/v2/${
-								taxonomy.restBase
-						  }?search=${ encodeURIComponent(
-								search
-						  ) }&per_page=10`;
+					const separator = wpRestBase.includes( 'rest_route=' )
+						? '&'
+						: '?';
+					const taxUrl = `${ wpRestBase }wp/v2/${
+						taxonomy.restBase
+					}${ separator }search=${ encodeURIComponent(
+						search
+					) }&per_page=10`;
 
 					const response = await fetch( taxUrl, {
 						headers: { 'X-WP-Nonce': restNonce },
+						signal: controller.signal,
 					} );
 
-					if ( response.ok ) {
-						const results = await response.json();
-						setSuggestions( results.map( ( term ) => term.name ) );
+					if ( ! response.ok ) {
+						setSuggestions( [] );
+						return;
 					}
+
+					const results = await response.json();
+					setSuggestions(
+						results.map( ( term ) => unescapeString( term.name ) )
+					);
 				} catch ( error ) {
-					setSuggestions( [] );
+					if ( error.name !== 'AbortError' ) {
+						setSuggestions( [] );
+					}
 				}
 			}, 300 );
 		},

--- a/src/components/TaxonomyPanel.js
+++ b/src/components/TaxonomyPanel.js
@@ -1,0 +1,258 @@
+/**
+ * Taxonomy Panel Component
+ *
+ * Renders a panel for a single custom taxonomy: a hierarchical checkbox
+ * tree (mirroring CategoryPanel) for hierarchical taxonomies, or a
+ * FormTokenField for flat taxonomies.
+ *
+ * @package
+ */
+
+/**
+ * WordPress dependencies
+ */
+import { useCallback, useMemo, useRef, useState } from '@wordpress/element';
+import {
+	CheckboxControl,
+	FormTokenField,
+	PanelBody,
+	SearchControl,
+} from '@wordpress/components';
+import { __ } from '@wordpress/i18n';
+
+/**
+ * Internal dependencies
+ */
+import {
+	buildTermsTree,
+	getFilterMatcher,
+	unescapeString,
+} from '../utils/terms';
+import { getWpRestBaseUrl } from '../utils/rest';
+
+const MIN_TERMS_COUNT_FOR_FILTER = 8;
+
+/**
+ * Render a list of terms as hierarchical checkboxes.
+ *
+ * @param {Array}    terms           Terms tree nodes.
+ * @param {Array}    selectedTermIds Selected term IDs.
+ * @param {Function} onToggle        Called with a term ID to toggle.
+ * @return {JSX.Element[]} Rendered term checkboxes.
+ */
+function renderTerms( terms, selectedTermIds, onToggle ) {
+	return terms.map( ( term ) => (
+		<div
+			key={ term.id }
+			className="press-this-editor__hierarchical-terms-choice"
+		>
+			<CheckboxControl
+				__nextHasNoMarginBottom
+				checked={ selectedTermIds.includes( term.id ) }
+				onChange={ () => onToggle( term.id ) }
+				label={ unescapeString( term.name ) }
+			/>
+			{ !! term.children.length && (
+				<div className="press-this-editor__hierarchical-terms-subchoices">
+					{ renderTerms( term.children, selectedTermIds, onToggle ) }
+				</div>
+			) }
+		</div>
+	) );
+}
+
+/**
+ * Hierarchical taxonomy panel: checkbox tree, same interaction as CategoryPanel.
+ *
+ * @param {Object}   props                   Component props.
+ * @param {Object}   props.taxonomy          Taxonomy data { name, label, terms }.
+ * @param {Array}    props.selectedTermIds   Selected term IDs.
+ * @param {Function} props.onSelectionChange State updater for selected IDs.
+ * @return {JSX.Element} Hierarchical taxonomy panel.
+ */
+function HierarchicalTaxonomyPanel( {
+	taxonomy,
+	selectedTermIds,
+	onSelectionChange,
+} ) {
+	const [ filterValue, setFilterValue ] = useState( '' );
+
+	const termsTree = useMemo(
+		() => buildTermsTree( taxonomy.terms ),
+		[ taxonomy.terms ]
+	);
+
+	const filteredTermsTree = useMemo( () => {
+		if ( filterValue === '' ) {
+			return [];
+		}
+		return termsTree
+			.map( getFilterMatcher( filterValue ) )
+			.filter( ( term ) => term );
+	}, [ termsTree, filterValue ] );
+
+	const handleToggle = useCallback(
+		( termId ) => {
+			onSelectionChange( ( prev ) => {
+				if ( prev.includes( termId ) ) {
+					return prev.filter( ( id ) => id !== termId );
+				}
+				return [ ...prev, termId ];
+			} );
+		},
+		[ onSelectionChange ]
+	);
+
+	const displayedTerms = filterValue !== '' ? filteredTermsTree : termsTree;
+	const showFilter = taxonomy.terms.length >= MIN_TERMS_COUNT_FOR_FILTER;
+
+	return (
+		<PanelBody title={ taxonomy.label } initialOpen={ false }>
+			{ showFilter && (
+				<SearchControl
+					__nextHasNoMarginBottom
+					label={ taxonomy.label }
+					placeholder={ taxonomy.label }
+					value={ filterValue }
+					onChange={ setFilterValue }
+					className="press-this-editor__categories-search"
+				/>
+			) }
+
+			<div
+				className="press-this-editor__hierarchical-terms-list"
+				tabIndex={ 0 }
+				role="group"
+				aria-label={ taxonomy.label }
+			>
+				{ displayedTerms.length > 0 ? (
+					renderTerms( displayedTerms, selectedTermIds, handleToggle )
+				) : (
+					<p className="press-this-editor__categories-no-results">
+						{ __( 'No terms found.', 'press-this' ) }
+					</p>
+				) }
+			</div>
+		</PanelBody>
+	);
+}
+
+/**
+ * Flat taxonomy panel: token field, same interaction as the Tags panel.
+ *
+ * @param {Object}   props                   Component props.
+ * @param {Object}   props.taxonomy          Taxonomy data { name, label, restBase }.
+ * @param {Array}    props.selectedTermNames Selected term names.
+ * @param {Function} props.onSelectionChange State updater for selected names.
+ * @param {string}   props.restUrl           Press This REST URL, used to derive the core REST base.
+ * @param {string}   props.restNonce         REST nonce.
+ * @return {JSX.Element} Flat taxonomy panel.
+ */
+function FlatTaxonomyPanel( {
+	taxonomy,
+	selectedTermNames,
+	onSelectionChange,
+	restUrl,
+	restNonce,
+} ) {
+	const [ suggestions, setSuggestions ] = useState( [] );
+	const searchTimeout = useRef( null );
+
+	const searchTerms = useCallback(
+		( search ) => {
+			if ( searchTimeout.current ) {
+				clearTimeout( searchTimeout.current );
+			}
+
+			if ( ! search || search.length < 2 || ! taxonomy.restBase ) {
+				setSuggestions( [] );
+				return;
+			}
+
+			searchTimeout.current = setTimeout( async () => {
+				try {
+					const wpRestBase = getWpRestBaseUrl( restUrl );
+					const taxUrl = wpRestBase.includes( 'rest_route=' )
+						? `${ wpRestBase }wp/v2/${
+								taxonomy.restBase
+						  }&search=${ encodeURIComponent(
+								search
+						  ) }&per_page=10`
+						: `${ wpRestBase }wp/v2/${
+								taxonomy.restBase
+						  }?search=${ encodeURIComponent(
+								search
+						  ) }&per_page=10`;
+
+					const response = await fetch( taxUrl, {
+						headers: { 'X-WP-Nonce': restNonce },
+					} );
+
+					if ( response.ok ) {
+						const results = await response.json();
+						setSuggestions( results.map( ( term ) => term.name ) );
+					}
+				} catch ( error ) {
+					setSuggestions( [] );
+				}
+			}, 300 );
+		},
+		[ restUrl, restNonce, taxonomy.restBase ]
+	);
+
+	return (
+		<PanelBody title={ taxonomy.label } initialOpen={ false }>
+			<FormTokenField
+				label={ taxonomy.label }
+				value={ selectedTermNames }
+				suggestions={ suggestions }
+				onChange={ onSelectionChange }
+				onInputChange={ searchTerms }
+				placeholder={ taxonomy.label }
+				__experimentalExpandOnFocus
+				__experimentalShowHowTo={ false }
+				__next40pxDefaultSize
+				__nextHasNoMarginBottom
+			/>
+		</PanelBody>
+	);
+}
+
+/**
+ * Taxonomy Panel component - dispatches to hierarchical or flat rendering.
+ *
+ * @param {Object}   props                   Component props.
+ * @param {Object}   props.taxonomy          Taxonomy data from press_this_taxonomies.
+ * @param {Array}    props.selectedTerms     Selected term IDs (hierarchical) or names (flat).
+ * @param {Function} props.onSelectionChange State updater for the selection.
+ * @param {string}   props.restUrl           Press This REST URL.
+ * @param {string}   props.restNonce         REST nonce.
+ * @return {JSX.Element} Taxonomy panel.
+ */
+export default function TaxonomyPanel( {
+	taxonomy,
+	selectedTerms,
+	onSelectionChange,
+	restUrl,
+	restNonce,
+} ) {
+	if ( taxonomy.hierarchical ) {
+		return (
+			<HierarchicalTaxonomyPanel
+				taxonomy={ taxonomy }
+				selectedTermIds={ selectedTerms }
+				onSelectionChange={ onSelectionChange }
+			/>
+		);
+	}
+
+	return (
+		<FlatTaxonomyPanel
+			taxonomy={ taxonomy }
+			selectedTermNames={ selectedTerms }
+			onSelectionChange={ onSelectionChange }
+			restUrl={ restUrl }
+			restNonce={ restNonce }
+		/>
+	);
+}

--- a/src/utils/index.js
+++ b/src/utils/index.js
@@ -14,3 +14,5 @@ export {
 } from './html-parser';
 
 export { isStandaloneMode } from './standalone';
+
+export { getWpRestBaseUrl } from './rest';

--- a/src/utils/rest.js
+++ b/src/utils/rest.js
@@ -1,0 +1,27 @@
+/**
+ * REST API URL utilities.
+ *
+ * @package
+ */
+
+/**
+ * Build the WordPress REST API base URL for core endpoints.
+ *
+ * Handles both pretty permalinks (/wp-json/) and index.php?rest_route= formats.
+ *
+ * @param {string} pressThisRestUrl The Press This REST URL (e.g., /wp-json/press-this/v1/ or index.php?rest_route=/press-this/v1/).
+ * @return {string} The base URL for WordPress core REST endpoints.
+ */
+export function getWpRestBaseUrl( pressThisRestUrl ) {
+	// Check if using index.php?rest_route= format.
+	if ( pressThisRestUrl.includes( 'rest_route=' ) ) {
+		// Extract the base URL up to and including rest_route=.
+		const match = pressThisRestUrl.match( /^(.*[?&]rest_route=)/ );
+		if ( match ) {
+			return match[ 1 ] + '/';
+		}
+	}
+
+	// Pretty permalinks format - replace the namespace.
+	return pressThisRestUrl.replace( /press-this\/v1\/$/, '' );
+}

--- a/tests/components/TaxonomyPanel.test.js
+++ b/tests/components/TaxonomyPanel.test.js
@@ -1,0 +1,93 @@
+/**
+ * Taxonomy Panel Component Tests
+ *
+ * Uses source-reading pattern to verify component implementation,
+ * matching CategoryPanel.test.js.
+ *
+ * @package press-this
+ */
+
+const fs = require( 'fs' );
+const path = require( 'path' );
+
+describe( 'TaxonomyPanel', () => {
+	let sourceContent;
+
+	beforeAll( () => {
+		const sourcePath = path.resolve(
+			__dirname,
+			'../../src/components/TaxonomyPanel.js'
+		);
+		sourceContent = fs.readFileSync( sourcePath, 'utf8' );
+	} );
+
+	describe( 'Component Structure', () => {
+		test( 'exports a default function component', () => {
+			expect( sourceContent ).toMatch(
+				/export\s+default\s+function\s+TaxonomyPanel/
+			);
+		} );
+
+		test( 'dispatches to hierarchical or flat rendering based on taxonomy.hierarchical', () => {
+			expect( sourceContent ).toMatch( /taxonomy\.hierarchical/ );
+			expect( sourceContent ).toContain( 'HierarchicalTaxonomyPanel' );
+			expect( sourceContent ).toContain( 'FlatTaxonomyPanel' );
+		} );
+	} );
+
+	describe( 'Hierarchical Taxonomy Panel', () => {
+		test( 'renders within a PanelBody titled with the taxonomy label', () => {
+			expect( sourceContent ).toMatch(
+				/<PanelBody\s+title=\{\s*taxonomy\.label\s*\}/
+			);
+		} );
+
+		test( 'builds a terms tree via buildTermsTree', () => {
+			expect( sourceContent ).toMatch(
+				/import\s*\{[^}]*buildTermsTree[^}]*\}/
+			);
+			expect( sourceContent ).toContain(
+				'buildTermsTree( taxonomy.terms )'
+			);
+		} );
+
+		test( 'renders terms as CheckboxControl components', () => {
+			expect( sourceContent ).toContain( '<CheckboxControl' );
+		} );
+
+		test( 'toggles term selection by adding or removing from array', () => {
+			expect( sourceContent ).toMatch(
+				/prev\.includes\(\s*termId\s*\)/
+			);
+			expect( sourceContent ).toMatch(
+				/prev\.filter\(\s*\(\s*id\s*\)\s*=>\s*id\s*!==\s*termId\s*\)/
+			);
+		} );
+
+		test( 'uses getFilterMatcher for search filtering', () => {
+			expect( sourceContent ).toMatch(
+				/import\s*\{[^}]*getFilterMatcher[^}]*\}/
+			);
+			expect( sourceContent ).toContain(
+				'getFilterMatcher( filterValue )'
+			);
+		} );
+	} );
+
+	describe( 'Flat Taxonomy Panel', () => {
+		test( 'renders a FormTokenField', () => {
+			expect( sourceContent ).toContain( '<FormTokenField' );
+		} );
+
+		test( 'builds REST suggestions URL from taxonomy.restBase', () => {
+			expect( sourceContent ).toMatch( /taxonomy\.restBase/ );
+			expect( sourceContent ).toMatch( /wp\/v2\/\$\{\s*taxonomy\.restBase\s*\}/ );
+		} );
+
+		test( 'skips suggestions when restBase is empty', () => {
+			expect( sourceContent ).toMatch(
+				/!\s*taxonomy\.restBase/
+			);
+		} );
+	} );
+} );

--- a/tests/components/TaxonomyPanel.test.js
+++ b/tests/components/TaxonomyPanel.test.js
@@ -46,8 +46,8 @@ describe( 'TaxonomyPanel', () => {
 			expect( sourceContent ).toMatch(
 				/import\s*\{[^}]*buildTermsTree[^}]*\}/
 			);
-			expect( sourceContent ).toContain(
-				'buildTermsTree( taxonomy.terms )'
+			expect( sourceContent ).toMatch(
+				/buildTermsTree\(\s*taxonomy\.terms/
 			);
 		} );
 

--- a/tests/components/custom-taxonomies-wiring.test.js
+++ b/tests/components/custom-taxonomies-wiring.test.js
@@ -1,0 +1,68 @@
+/**
+ * Custom Taxonomies — wiring tests.
+ *
+ * Verifies the custom taxonomies data flows from App.js into
+ * PressThisEditor, is rendered via TaxonomyPanel, and is included in the
+ * save payload sent to the REST API.
+ *
+ * Issue: https://github.com/WordPress/press-this/issues/9
+ *
+ * @package press-this
+ */
+
+const fs = require( 'fs' );
+const path = require( 'path' );
+
+describe( 'Custom taxonomies wiring', () => {
+	let appSource;
+	let editorSource;
+
+	beforeAll( () => {
+		appSource = fs.readFileSync(
+			path.resolve( __dirname, '../../src/App.js' ),
+			'utf8'
+		);
+		editorSource = fs.readFileSync(
+			path.resolve( __dirname, '../../src/components/PressThisEditor.js' ),
+			'utf8'
+		);
+	} );
+
+	test( 'App.js passes data.taxonomies through to PressThisEditor', () => {
+		expect( appSource ).toMatch(
+			/taxonomies=\{\s*data\.taxonomies\s*\|\|\s*\[\s*\]\s*\}/
+		);
+	} );
+
+	test( 'PressThisEditor accepts a taxonomies prop', () => {
+		expect( editorSource ).toMatch( /taxonomies\s*=\s*\[\s*\]/ );
+	} );
+
+	test( 'PressThisEditor tracks per-taxonomy term selections', () => {
+		expect( editorSource ).toMatch(
+			/const\s*\[\s*taxonomyTerms\s*,\s*setTaxonomyTerms\s*\]\s*=\s*useState\(\s*\{\s*\}\s*\)/
+		);
+	} );
+
+	test( 'PressThisEditor imports and renders TaxonomyPanel per taxonomy', () => {
+		expect( editorSource ).toMatch(
+			/import\s+TaxonomyPanel\s+from\s+['"]\.\/TaxonomyPanel['"]/
+		);
+		expect( editorSource ).toMatch(
+			/taxonomies\.map\(\s*\(\s*taxonomy\s*\)\s*=>/
+		);
+		expect( editorSource ).toContain( '<TaxonomyPanel' );
+	} );
+
+	test( 'save payload includes tax_input built from taxonomyTerms', () => {
+		expect( editorSource ).toMatch( /tax_input:\s*taxonomyTerms/ );
+	} );
+
+	test( 'handleSave dependency array includes taxonomyTerms', () => {
+		const handleSaveMatch = editorSource.match(
+			/const handleSave = useCallback\(([\s\S]*?)\n\t\);/
+		);
+		expect( handleSaveMatch ).not.toBeNull();
+		expect( handleSaveMatch[ 1 ] ).toContain( 'taxonomyTerms' );
+	} );
+} );

--- a/tests/components/flat-taxonomy-panel-search.test.js
+++ b/tests/components/flat-taxonomy-panel-search.test.js
@@ -1,0 +1,323 @@
+/**
+ * FlatTaxonomyPanel search — behavior tests.
+ *
+ * The reviewer asked for real rendering coverage of the flat-panel term
+ * search: the debounced REST lookup must render decoded suggestion names,
+ * an in-flight request must not be able to overwrite a newer one's results,
+ * a failed response must clear stale suggestions, and unmounting the panel
+ * must abort the pending request.
+ *
+ * Strategy: render the real component through createRoot() with lightweight
+ * DOM stubs for the @wordpress/components inputs, and a controllable
+ * global.fetch. Same approach as connected-scraped-media-panel.test.js.
+ *
+ * @package press-this
+ */
+
+// Tell React 18 that act() in this file is the test runner's act.
+globalThis.IS_REACT_ACT_ENVIRONMENT = true;
+
+jest.mock( '@wordpress/element', () => {
+	const React = require( 'react' );
+	return {
+		useState: React.useState,
+		useEffect: React.useEffect,
+		useCallback: React.useCallback,
+		useMemo: React.useMemo,
+		useRef: React.useRef,
+		createElement: React.createElement,
+		Fragment: React.Fragment,
+	};
+} );
+
+jest.mock( '@wordpress/i18n', () => ( {
+	__: ( s ) => s,
+} ) );
+
+jest.mock( '@wordpress/components', () => {
+	const React = require( 'react' );
+	const handlers = {};
+	return {
+		// Exposed so tests can invoke the panel's own onInputChange handler
+		// the way FormTokenField would after its internal input handling.
+		__handlers: handlers,
+		PanelBody: ( { children } ) =>
+			React.createElement(
+				'div',
+				{ className: 'test-panel-body' },
+				children
+			),
+		CheckboxControl: () =>
+			React.createElement( 'input', { type: 'checkbox' } ),
+		SearchControl: () => React.createElement( 'input', { type: 'search' } ),
+		FormTokenField: ( { label, value, suggestions, onInputChange } ) => {
+			handlers.onInputChange = onInputChange;
+			return React.createElement(
+				'div',
+				{ className: 'test-token-field', 'data-label': label },
+				React.createElement(
+					'ul',
+					{ className: 'test-suggestions' },
+					suggestions.map( ( name ) =>
+						React.createElement( 'li', { key: name }, name )
+					)
+				),
+				React.createElement(
+					'span',
+					{ className: 'test-selected', hidden: true },
+					value.join( ',' )
+				)
+			);
+		},
+	};
+} );
+
+const React = require( 'react' );
+const { createRoot } = require( 'react-dom/client' );
+const { act } = React;
+const components = require( '@wordpress/components' );
+const TaxonomyPanel = require( '../../src/components/TaxonomyPanel' ).default;
+
+const TAXONOMY = {
+	name: 'genre',
+	label: 'Genres',
+	hierarchical: false,
+	restBase: 'genres',
+};
+
+function okResponse( terms ) {
+	return {
+		ok: true,
+		json: async () => terms,
+	};
+}
+
+function typeInto( text ) {
+	return act( async () => {
+		components.__handlers.onInputChange( text );
+	} );
+}
+
+function suggestionTexts( container ) {
+	return Array.from(
+		container.querySelectorAll( '.test-suggestions li' )
+	).map( ( li ) => li.textContent );
+}
+
+describe( 'FlatTaxonomyPanel search', () => {
+	let container;
+	let root;
+	let fetchCalls;
+
+	beforeEach( () => {
+		jest.useFakeTimers();
+		fetchCalls = [];
+		global.fetch = jest.fn( ( url, options ) => {
+			fetchCalls.push( { url, options } );
+			return Promise.resolve( okResponse( [] ) );
+		} );
+		container = document.createElement( 'div' );
+		document.body.appendChild( container );
+	} );
+
+	afterEach( async () => {
+		if ( root ) {
+			await act( async () => {
+				root.unmount();
+			} );
+			root = null;
+		}
+		container.remove();
+		jest.useRealTimers();
+		jest.restoreAllMocks();
+		delete global.fetch;
+	} );
+
+	async function renderPanel( props = {} ) {
+		await act( async () => {
+			root = createRoot( container );
+			root.render(
+				React.createElement( TaxonomyPanel, {
+					taxonomy: TAXONOMY,
+					selectedTerms: [],
+					onSelectionChange: () => {},
+					restUrl: '/wp-json/press-this/v1/',
+					restNonce: 'test-nonce',
+					...props,
+				} )
+			);
+		} );
+	}
+
+	async function searchFor( text ) {
+		await typeInto( text );
+		// Fire the 300ms debounce, then flush the fetch/json promise chain
+		// so the resulting state update renders inside act().
+		act( () => {
+			jest.advanceTimersByTime( 300 );
+		} );
+		await act( async () => {
+			await Promise.resolve();
+		} );
+	}
+
+	test( 'renders fetched suggestions with entities decoded', async () => {
+		// Record the call ourselves: mockImplementationOnce replaces the
+		// base implementation, including its fetchCalls.push side effect.
+		global.fetch.mockImplementationOnce( ( url, options ) => {
+			fetchCalls.push( { url, options } );
+			return Promise.resolve(
+				okResponse( [
+					{ id: 1, name: 'Ampersand &amp; Sons' },
+					{ id: 2, name: 'Science Fiction' },
+				] )
+			);
+		} );
+
+		await renderPanel();
+		await searchFor( 'son' );
+
+		expect( fetchCalls ).toHaveLength( 1 );
+		expect( fetchCalls[ 0 ].url ).toBe(
+			'/wp-json/wp/v2/genres?search=son&per_page=10'
+		);
+		expect( fetchCalls[ 0 ].options.headers[ 'X-WP-Nonce' ] ).toBe(
+			'test-nonce'
+		);
+		expect( suggestionTexts( container ) ).toEqual( [
+			'Ampersand & Sons',
+			'Science Fiction',
+		] );
+	} );
+
+	test( 'a slower earlier response cannot overwrite newer suggestions', async () => {
+		let rejectSlow;
+		let slowSignal;
+		// A real fetch rejects with an AbortError once its signal aborts.
+		// Mirror that so the mock behaves like the browser: the slow
+		// request never delivers results after the newer search aborts it.
+		const slowResponse = new Promise( ( resolve, reject ) => {
+			rejectSlow = () =>
+				reject(
+					Object.assign( new Error( 'Aborted' ), {
+						name: 'AbortError',
+					} )
+				);
+		} );
+		const trackSlow = ( url, options ) => {
+			slowSignal = options.signal;
+			slowSignal.addEventListener( 'abort', () => rejectSlow() );
+			return slowResponse;
+		};
+
+		global.fetch.mockImplementation( ( url, options ) => {
+			// Keep recording: this replaces the base implementation too.
+			fetchCalls.push( { url, options } );
+			if ( url.includes( 'search=fa&' ) ) {
+				return trackSlow( url, options );
+			}
+			return Promise.resolve( okResponse( [ { name: 'Fantasy' } ] ) );
+		} );
+
+		await renderPanel();
+
+		// First search starts a slow request.
+		await typeInto( 'fa' );
+		act( () => {
+			jest.advanceTimersByTime( 300 );
+		} );
+		expect( fetchCalls ).toHaveLength( 1 );
+
+		// Second search aborts the first and gets a fast response.
+		await typeInto( 'fant' );
+		act( () => {
+			jest.advanceTimersByTime( 300 );
+		} );
+		await act( async () => {
+			await Promise.resolve();
+		} );
+		expect( fetchCalls ).toHaveLength( 2 );
+		expect( suggestionTexts( container ) ).toEqual( [ 'Fantasy' ] );
+
+		// The aborted request can no longer touch suggestions: the abort
+		// rejects its fetch, and the component ignores AbortError.
+		expect( slowSignal.aborted ).toBe( true );
+		rejectSlow();
+		await act( async () => {
+			await Promise.resolve();
+			await Promise.resolve();
+		} );
+		expect( suggestionTexts( container ) ).toEqual( [ 'Fantasy' ] );
+	} );
+
+	test( 'a non-OK response clears suggestions instead of leaving stale ones', async () => {
+		await renderPanel();
+
+		// First establish real suggestions so there is something stale to clear.
+		global.fetch.mockImplementationOnce( ( url, options ) => {
+			fetchCalls.push( { url, options } );
+			return Promise.resolve(
+				okResponse( [ { name: 'Song' }, { name: 'Sonic' } ] )
+			);
+		} );
+		await typeInto( 'son' );
+		act( () => {
+			jest.advanceTimersByTime( 300 );
+		} );
+		await act( async () => {
+			await Promise.resolve();
+		} );
+
+		expect( fetchCalls ).toHaveLength( 1 );
+		expect( suggestionTexts( container ) ).toEqual( [ 'Song', 'Sonic' ] );
+
+		// A failed search must replace them with nothing.
+		global.fetch.mockImplementationOnce( ( url, options ) => {
+			fetchCalls.push( { url, options } );
+			return Promise.resolve( { ok: false, status: 500 } );
+		} );
+		await typeInto( 'sonn' );
+		act( () => {
+			jest.advanceTimersByTime( 300 );
+		} );
+		await act( async () => {
+			await Promise.resolve();
+		} );
+
+		expect( fetchCalls ).toHaveLength( 2 );
+		expect( suggestionTexts( container ) ).toEqual( [] );
+	} );
+
+	test( 'unmounting while a request is pending aborts it', async () => {
+		let capturedSignal;
+
+		global.fetch.mockImplementationOnce( ( url, options ) => {
+			fetchCalls.push( { url, options } );
+			capturedSignal = options.signal;
+			return new Promise( () => {} ); // Never settles.
+		} );
+
+		await renderPanel();
+		await typeInto( 'son' );
+		act( () => {
+			jest.advanceTimersByTime( 300 );
+		} );
+		expect( fetchCalls ).toHaveLength( 1 );
+		expect( capturedSignal.aborted ).toBe( false );
+
+		await act( async () => {
+			root.unmount();
+		} );
+		root = null;
+
+		expect( capturedSignal.aborted ).toBe( true );
+	} );
+
+	test( 'short input never triggers a request', async () => {
+		await renderPanel();
+		await searchFor( 's' );
+
+		expect( fetchCalls ).toHaveLength( 0 );
+		expect( suggestionTexts( container ) ).toEqual( [] );
+	} );
+} );

--- a/tests/php/test-press-this-plugin.php
+++ b/tests/php/test-press-this-plugin.php
@@ -39,6 +39,9 @@ class Test_WP_Press_This_Plugin extends BaseTestCase {
 	public function set_up() {
 		parent::set_up();
 
+		// Ensure WordPress default roles are available.
+		populate_roles();
+
 		// Load the plugin class.
 		require_once dirname( dirname( __DIR__ ) ) . '/class-wp-press-this-plugin.php';
 
@@ -83,13 +86,14 @@ class Test_WP_Press_This_Plugin extends BaseTestCase {
 
 		// Clean up any test-registered taxonomies, as a backstop in case
 		// a test failed before reaching its own unregister_taxonomy() call.
-		foreach ( array( 'pt_test_genre', 'pt_test_rating', 'pt_test_hidden' ) as $test_tax ) {
+		foreach ( array( 'pt_test_genre', 'pt_test_rating', 'pt_test_hidden', 'pt_test_page_only', 'pt_test_locked' ) as $test_tax ) {
 			if ( taxonomy_exists( $test_tax ) ) {
 				unregister_taxonomy( $test_tax );
 			}
 		}
 
 		remove_all_filters( 'press_this_taxonomies' );
+		remove_all_filters( 'press_this_post_type' );
 
 		parent::tear_down();
 		$_POST = array();
@@ -184,6 +188,48 @@ class Test_WP_Press_This_Plugin extends BaseTestCase {
 
 		$terms = wp_get_post_terms( $this->test_post_id, 'pt_test_genre', array( 'fields' => 'names' ) );
 		$this->assertContains( 'Sci-Fi', $terms );
+
+		unregister_taxonomy( 'pt_test_genre' );
+	}
+
+	/**
+	 * Test: save_post() AJAX handler clears a custom taxonomy's terms when
+	 * tax_input sends an empty array for it (deselect-all flow).
+	 *
+	 * @covers WP_Press_This_Plugin::save_post
+	 */
+	public function test_save_post_clears_custom_taxonomy_with_empty_tax_input() {
+		register_taxonomy(
+			'pt_test_genre',
+			'post',
+			array(
+				'public'       => true,
+				'show_ui'      => true,
+				'hierarchical' => false,
+				'labels'       => array( 'name' => 'Genres' ),
+			)
+		);
+
+		wp_set_object_terms( $this->test_post_id, array( 'Stale' ), 'pt_test_genre' );
+
+		$_POST['post_ID']      = $this->test_post_id;
+		$_POST['_wpnonce']     = wp_create_nonce( 'update-post_' . $this->test_post_id );
+		$_POST['post_title']   = 'Genre Clear Test';
+		$_POST['post_content'] = '<p>Content</p>';
+		$_POST['tax_input']    = array( 'pt_test_genre' => array() );
+
+		ob_start();
+		try {
+			$this->plugin->save_post();
+		} catch ( WPDieException $e ) {
+			// Expected.
+		}
+		ob_end_clean();
+
+		$this->assertSame(
+			array(),
+			wp_get_object_terms( $this->test_post_id, 'pt_test_genre', array( 'fields' => 'ids' ) )
+		);
 
 		unregister_taxonomy( 'pt_test_genre' );
 	}
@@ -558,8 +604,8 @@ class Test_WP_Press_This_Plugin extends BaseTestCase {
 			)
 		);
 
-		$term = wp_insert_term( 'Fiction', 'pt_test_genre' );
-		$this->assertNotInstanceOf( 'WP_Error', $term );
+		$term    = wp_insert_term( 'Fiction', 'pt_test_genre' );
+		$term_id = is_wp_error( $term ) ? (int) $term->get_error_data() : (int) $term['term_id'];
 
 		$data = $this->get_press_this_data_from_html();
 
@@ -576,8 +622,12 @@ class Test_WP_Press_This_Plugin extends BaseTestCase {
 		$this->assertNotFalse( $genre, 'pt_test_genre should be present in taxonomies data.' );
 		$this->assertSame( 'Genres', $genre['label'] );
 		$this->assertTrue( $genre['hierarchical'] );
-		$this->assertCount( 1, $genre['terms'] );
-		$this->assertSame( 'Fiction', $genre['terms'][0]['name'] );
+		// Match by term id: WorDBless persists term rows across tests in the
+		// shared SQLite database, so unrelated tests may leave extra terms
+		// behind on this taxonomy.
+		$term_names = wp_list_pluck( $genre['terms'], 'name', 'id' );
+		$this->assertArrayHasKey( $term_id, $term_names );
+		$this->assertSame( 'Fiction', $term_names[ $term_id ] );
 
 		unregister_taxonomy( 'pt_test_genre' );
 	}
@@ -676,7 +726,6 @@ class Test_WP_Press_This_Plugin extends BaseTestCase {
 						'label'        => 'Injected',
 						'hierarchical' => false,
 						'restBase'     => '',
-						'canEditTerms' => false,
 						'terms'        => array(),
 					),
 				);
@@ -689,6 +738,82 @@ class Test_WP_Press_This_Plugin extends BaseTestCase {
 
 		$this->assertCount( 1, $data['taxonomies'] );
 		$this->assertSame( 'injected', $data['taxonomies'][0]['name'] );
+	}
+
+	/**
+	 * Test: a filter callback returning null (e.g. a forgotten return in a
+	 * removal-only filter) does not fatal; the list falls back to empty.
+	 *
+	 * @covers WP_Press_This_Plugin::html
+	 */
+	public function test_html_taxonomies_filter_null_return_falls_back_to_array() {
+		add_filter( 'press_this_taxonomies', '__return_null' );
+
+		$data = $this->get_press_this_data_from_html();
+
+		$this->assertArrayHasKey( 'taxonomies', $data );
+		$this->assertSame( array(), $data['taxonomies'] );
+	}
+
+	/**
+	 * Test: malformed entries injected by the press_this_taxonomies filter are
+	 * dropped, and surviving entries have their fields sanitized.
+	 *
+	 * @covers WP_Press_This_Plugin::html
+	 */
+	public function test_html_taxonomies_filter_sanitizes_entries() {
+		add_filter(
+			'press_this_taxonomies',
+			function () {
+				return array(
+					// Well-formed entry: survives, fields normalized.
+					array(
+						'name'         => 'injected',
+						'label'        => 'Injected <b>Label</b>',
+						'hierarchical' => 1,
+						'restBase'     => 'injected-terms',
+						'terms'        => array(
+							array( 'id' => '5', 'name' => 'Term <i>One</i>', 'parent' => '2', 'slug' => 'term-one' ),
+							'not-an-array',
+							array( 'no-id-key' => true ),
+							array( 'id' => 'oops', 'name' => 'Bad' ),
+						),
+					),
+					// Not an array: dropped.
+					'string-entry',
+					// Missing name: dropped.
+					array( 'label' => 'No Name' ),
+					// Empty name: dropped.
+					array( 'name' => '', 'label' => 'Empty Name' ),
+					// Wrong hierarchical type: dropped.
+					array( 'name' => 'badbool', 'label' => 'B', 'hierarchical' => 'yes', 'restBase' => '', 'terms' => array() ),
+					// Numeric hierarchical flag: kept, coerced to true.
+					array( 'name' => 'numbool', 'label' => 'N', 'hierarchical' => 1, 'restBase' => '', 'terms' => array() ),
+				);
+			}
+		);
+
+		$data = $this->get_press_this_data_from_html();
+
+		// 'injected' survives; 'numbool' survives with a coerced flag.
+		$this->assertCount( 2, $data['taxonomies'] );
+
+		$entry = $data['taxonomies'][0];
+		$this->assertSame( 'injected', $entry['name'] );
+		$this->assertSame( 'Injected Label', $entry['label'] );
+		$this->assertTrue( $entry['hierarchical'] );
+		$this->assertSame( 'injected-terms', $entry['restBase'] );
+
+		// Only the well-formed term survives, with cast id/parent and clean strings.
+		$this->assertCount( 1, $entry['terms'] );
+		$term = $entry['terms'][0];
+		$this->assertSame( 5, $term['id'] );
+		$this->assertSame( 'Term One', $term['name'] );
+		$this->assertSame( 2, $term['parent'] );
+		$this->assertSame( 'term-one', $term['slug'] );
+
+		$this->assertSame( 'numbool', $data['taxonomies'][1]['name'] );
+		$this->assertTrue( $data['taxonomies'][1]['hierarchical'] );
 	}
 
 	/**

--- a/tests/php/test-press-this-plugin.php
+++ b/tests/php/test-press-this-plugin.php
@@ -81,6 +81,16 @@ class Test_WP_Press_This_Plugin extends BaseTestCase {
 			unregister_post_type( 'pt_test_no_tax' );
 		}
 
+		// Clean up any test-registered taxonomies, as a backstop in case
+		// a test failed before reaching its own unregister_taxonomy() call.
+		foreach ( array( 'pt_test_genre', 'pt_test_rating', 'pt_test_hidden' ) as $test_tax ) {
+			if ( taxonomy_exists( $test_tax ) ) {
+				unregister_taxonomy( $test_tax );
+			}
+		}
+
+		remove_all_filters( 'press_this_taxonomies' );
+
 		parent::tear_down();
 		$_POST = array();
 		$_GET  = array();
@@ -139,6 +149,109 @@ class Test_WP_Press_This_Plugin extends BaseTestCase {
 		// The original post title should not be changed.
 		$post = get_post( $this->test_post_id );
 		$this->assertNotEquals( 'Test Title', $post->post_title );
+	}
+
+	/**
+	 * Test: save_post() AJAX handler saves a custom taxonomy via tax_input.
+	 *
+	 * @covers WP_Press_This_Plugin::save_post
+	 */
+	public function test_save_post_handles_custom_taxonomy() {
+		register_taxonomy(
+			'pt_test_genre',
+			'post',
+			array(
+				'public'       => true,
+				'show_ui'      => true,
+				'hierarchical' => false,
+				'labels'       => array( 'name' => 'Genres' ),
+			)
+		);
+
+		$_POST['post_ID']      = $this->test_post_id;
+		$_POST['_wpnonce']     = wp_create_nonce( 'update-post_' . $this->test_post_id );
+		$_POST['post_title']   = 'Genre Test';
+		$_POST['post_content'] = '<p>Content</p>';
+		$_POST['tax_input']    = array( 'pt_test_genre' => array( 'Sci-Fi' ) );
+
+		ob_start();
+		try {
+			$this->plugin->save_post();
+		} catch ( WPDieException $e ) {
+			// Expected - wp_send_json_* calls wp_die().
+		}
+		ob_end_clean();
+
+		$terms = wp_get_post_terms( $this->test_post_id, 'pt_test_genre', array( 'fields' => 'names' ) );
+		$this->assertContains( 'Sci-Fi', $terms );
+
+		unregister_taxonomy( 'pt_test_genre' );
+	}
+
+	/**
+	 * Test: save_post() AJAX handler ignores tax_input for a taxonomy not
+	 * registered on the post's type.
+	 *
+	 * @covers WP_Press_This_Plugin::save_post
+	 */
+	public function test_save_post_ignores_tax_input_for_unregistered_taxonomy() {
+		register_taxonomy( 'pt_test_page_only', 'page', array( 'public' => true ) );
+
+		$_POST['post_ID']      = $this->test_post_id;
+		$_POST['_wpnonce']     = wp_create_nonce( 'update-post_' . $this->test_post_id );
+		$_POST['post_title']   = 'Unregistered Tax Test';
+		$_POST['post_content'] = '<p>Content</p>';
+		$_POST['tax_input']    = array( 'pt_test_page_only' => array( 'Should Not Save' ) );
+
+		ob_start();
+		try {
+			$this->plugin->save_post();
+		} catch ( WPDieException $e ) {
+			// Expected.
+		}
+		ob_end_clean();
+
+		$terms = wp_get_post_terms( $this->test_post_id, 'pt_test_page_only', array( 'fields' => 'names' ) );
+		$this->assertEmpty( $terms );
+
+		unregister_taxonomy( 'pt_test_page_only' );
+	}
+
+	/**
+	 * Test: save_post() AJAX handler ignores tax_input for a taxonomy
+	 * without show_ui, matching what's ever exposed to the panel.
+	 *
+	 * @covers WP_Press_This_Plugin::save_post
+	 */
+	public function test_save_post_ignores_tax_input_without_show_ui() {
+		register_taxonomy(
+			'pt_test_hidden',
+			'post',
+			array(
+				'public'  => true,
+				'show_ui' => false,
+				'labels'  => array( 'name' => 'Hidden' ),
+			)
+		);
+
+		$_POST['post_ID']      = $this->test_post_id;
+		$_POST['_wpnonce']     = wp_create_nonce( 'update-post_' . $this->test_post_id );
+		$_POST['post_title']   = 'Hidden Tax Test';
+		$_POST['post_content'] = '<p>Content</p>';
+		$_POST['tax_input']    = array( 'pt_test_hidden' => array( 'Should Not Save' ) );
+
+		ob_start();
+		try {
+			$this->plugin->save_post();
+		} catch ( WPDieException $e ) {
+			// Expected.
+		}
+		ob_end_clean();
+
+		$terms = wp_get_post_terms( $this->test_post_id, 'pt_test_hidden', array( 'fields' => 'names' ) );
+		$this->assertEmpty( $terms );
+
+		unregister_taxonomy( 'pt_test_hidden' );
 	}
 
 	/**
@@ -425,6 +538,157 @@ class Test_WP_Press_This_Plugin extends BaseTestCase {
 		$this->assertFalse( $data['canEditCategories'], 'canEditCategories should be false for CPT without taxonomies.' );
 		$this->assertFalse( $data['canAssignTags'], 'canAssignTags should be false for CPT without taxonomies.' );
 		$this->assertEmpty( $data['categories'], 'categories should be empty for CPT without taxonomies.' );
+	}
+
+	/**
+	 * Test: a custom hierarchical taxonomy registered for 'post' appears in
+	 * the taxonomies data with its terms.
+	 *
+	 * @covers WP_Press_This_Plugin::html
+	 */
+	public function test_html_includes_custom_hierarchical_taxonomy() {
+		register_taxonomy(
+			'pt_test_genre',
+			'post',
+			array(
+				'public'       => true,
+				'show_ui'      => true,
+				'hierarchical' => true,
+				'labels'       => array( 'name' => 'Genres' ),
+			)
+		);
+
+		$term = wp_insert_term( 'Fiction', 'pt_test_genre' );
+		$this->assertNotInstanceOf( 'WP_Error', $term );
+
+		$data = $this->get_press_this_data_from_html();
+
+		$this->assertArrayHasKey( 'taxonomies', $data );
+		$genre = current(
+			array_filter(
+				$data['taxonomies'],
+				function ( $tax ) {
+					return 'pt_test_genre' === $tax['name'];
+				}
+			)
+		);
+
+		$this->assertNotFalse( $genre, 'pt_test_genre should be present in taxonomies data.' );
+		$this->assertSame( 'Genres', $genre['label'] );
+		$this->assertTrue( $genre['hierarchical'] );
+		$this->assertCount( 1, $genre['terms'] );
+		$this->assertSame( 'Fiction', $genre['terms'][0]['name'] );
+
+		unregister_taxonomy( 'pt_test_genre' );
+	}
+
+	/**
+	 * Test: a custom flat taxonomy registered for 'post' appears in the
+	 * taxonomies data without terms (terms are only bootstrapped for
+	 * hierarchical taxonomies; flat taxonomies use REST suggestions).
+	 *
+	 * @covers WP_Press_This_Plugin::html
+	 */
+	public function test_html_includes_custom_flat_taxonomy() {
+		register_taxonomy(
+			'pt_test_rating',
+			'post',
+			array(
+				'public'        => true,
+				'show_ui'       => true,
+				'hierarchical'  => false,
+				'show_in_rest'  => true,
+				'rest_base'     => 'ratings',
+				'labels'        => array( 'name' => 'Ratings' ),
+			)
+		);
+
+		$data = $this->get_press_this_data_from_html();
+
+		$rating = current(
+			array_filter(
+				$data['taxonomies'],
+				function ( $tax ) {
+					return 'pt_test_rating' === $tax['name'];
+				}
+			)
+		);
+
+		$this->assertNotFalse( $rating, 'pt_test_rating should be present in taxonomies data.' );
+		$this->assertFalse( $rating['hierarchical'] );
+		$this->assertSame( 'ratings', $rating['restBase'] );
+
+		unregister_taxonomy( 'pt_test_rating' );
+	}
+
+	/**
+	 * Test: category and post_tag are never duplicated into the custom
+	 * taxonomies list, since they have their own dedicated panels.
+	 *
+	 * @covers WP_Press_This_Plugin::html
+	 */
+	public function test_html_taxonomies_excludes_category_and_post_tag() {
+		$data = $this->get_press_this_data_from_html();
+
+		$names = wp_list_pluck( $data['taxonomies'], 'name' );
+
+		$this->assertNotContains( 'category', $names );
+		$this->assertNotContains( 'post_tag', $names );
+	}
+
+	/**
+	 * Test: a taxonomy without show_ui is not exposed in the panel data.
+	 *
+	 * @covers WP_Press_This_Plugin::html
+	 */
+	public function test_html_excludes_taxonomy_without_show_ui() {
+		register_taxonomy(
+			'pt_test_hidden',
+			'post',
+			array(
+				'public'  => true,
+				'show_ui' => false,
+				'labels'  => array( 'name' => 'Hidden' ),
+			)
+		);
+
+		$data  = $this->get_press_this_data_from_html();
+		$names = wp_list_pluck( $data['taxonomies'], 'name' );
+
+		$this->assertNotContains( 'pt_test_hidden', $names );
+
+		unregister_taxonomy( 'pt_test_hidden' );
+	}
+
+	/**
+	 * Test: the press_this_taxonomies filter can add or remove entries.
+	 *
+	 * @covers WP_Press_This_Plugin::html
+	 */
+	public function test_html_taxonomies_filter_can_modify_list() {
+		add_filter(
+			'press_this_taxonomies',
+			function ( $taxonomies_data, $post_type ) {
+				$this->assertSame( 'post', $post_type );
+				return array(
+					array(
+						'name'         => 'injected',
+						'label'        => 'Injected',
+						'hierarchical' => false,
+						'restBase'     => '',
+						'canEditTerms' => false,
+						'terms'        => array(),
+					),
+				);
+			},
+			10,
+			2
+		);
+
+		$data = $this->get_press_this_data_from_html();
+
+		$this->assertCount( 1, $data['taxonomies'] );
+		$this->assertSame( 'injected', $data['taxonomies'][0]['name'] );
 	}
 
 	/**

--- a/tests/php/test-rest-endpoints.php
+++ b/tests/php/test-rest-endpoints.php
@@ -371,6 +371,177 @@ class Test_Press_This_REST_Endpoints extends BaseTestCase {
 	}
 
 	/**
+	 * Test save handles a custom hierarchical taxonomy via tax_input.
+	 */
+	public function test_save_handles_custom_hierarchical_taxonomy() {
+		register_taxonomy(
+			'pt_test_genre',
+			'post',
+			array(
+				'public'       => true,
+				'show_ui'      => true,
+				'hierarchical' => true,
+				'labels'       => array( 'name' => 'Genres' ),
+			)
+		);
+
+		$term    = wp_insert_term( 'Fiction', 'pt_test_genre' );
+		$term_id = is_wp_error( $term ) ? $term->get_error_data()['term_id'] : $term['term_id'];
+
+		wp_set_current_user( $this->editor_user_id );
+
+		$request = new WP_REST_Request( 'POST', '/press-this/v1/save' );
+		$request->set_param( 'post_id', $this->test_post_id );
+		$request->set_param( 'title', 'Genre Test' );
+		$request->set_param( 'content', '<p>Content</p>' );
+		$request->set_param( 'tax_input', array( 'pt_test_genre' => array( $term_id ) ) );
+
+		press_this_rest_save_post( $request );
+
+		$terms = wp_get_post_terms( $this->test_post_id, 'pt_test_genre', array( 'fields' => 'ids' ) );
+		$this->assertContains( $term_id, $terms );
+
+		unregister_taxonomy( 'pt_test_genre' );
+	}
+
+	/**
+	 * Test save handles a custom flat taxonomy via tax_input.
+	 */
+	public function test_save_handles_custom_flat_taxonomy() {
+		register_taxonomy(
+			'pt_test_rating',
+			'post',
+			array(
+				'public'       => true,
+				'show_ui'      => true,
+				'hierarchical' => false,
+				'labels'       => array( 'name' => 'Ratings' ),
+			)
+		);
+
+		wp_set_current_user( $this->editor_user_id );
+
+		$request = new WP_REST_Request( 'POST', '/press-this/v1/save' );
+		$request->set_param( 'post_id', $this->test_post_id );
+		$request->set_param( 'title', 'Rating Test' );
+		$request->set_param( 'content', '<p>Content</p>' );
+		$request->set_param( 'tax_input', array( 'pt_test_rating' => array( 'Excellent' ) ) );
+
+		press_this_rest_save_post( $request );
+
+		$terms = wp_get_post_terms( $this->test_post_id, 'pt_test_rating', array( 'fields' => 'names' ) );
+		$this->assertContains( 'Excellent', $terms );
+
+		unregister_taxonomy( 'pt_test_rating' );
+	}
+
+	/**
+	 * Test save ignores tax_input for a taxonomy not registered on the post type.
+	 */
+	public function test_save_ignores_tax_input_for_unregistered_taxonomy() {
+		register_taxonomy( 'pt_test_page_only', 'page', array( 'public' => true ) );
+
+		wp_set_current_user( $this->editor_user_id );
+
+		$request = new WP_REST_Request( 'POST', '/press-this/v1/save' );
+		$request->set_param( 'post_id', $this->test_post_id );
+		$request->set_param( 'title', 'Unregistered Tax Test' );
+		$request->set_param( 'content', '<p>Content</p>' );
+		$request->set_param( 'tax_input', array( 'pt_test_page_only' => array( 'Should Not Save' ) ) );
+
+		$response = press_this_rest_save_post( $request );
+
+		$this->assertFalse( is_wp_error( $response ) );
+		$terms = wp_get_post_terms( $this->test_post_id, 'pt_test_page_only', array( 'fields' => 'names' ) );
+		$this->assertEmpty( $terms );
+
+		unregister_taxonomy( 'pt_test_page_only' );
+	}
+
+	/**
+	 * Test save ignores tax_input for a taxonomy without show_ui, matching
+	 * the gating applied when building the panel data (parity between
+	 * read and write sides).
+	 */
+	public function test_save_ignores_tax_input_without_show_ui() {
+		register_taxonomy(
+			'pt_test_hidden',
+			'post',
+			array(
+				'public'  => true,
+				'show_ui' => false,
+				'labels'  => array( 'name' => 'Hidden' ),
+			)
+		);
+
+		wp_set_current_user( $this->editor_user_id );
+
+		$request = new WP_REST_Request( 'POST', '/press-this/v1/save' );
+		$request->set_param( 'post_id', $this->test_post_id );
+		$request->set_param( 'title', 'Hidden Tax Test' );
+		$request->set_param( 'content', '<p>Content</p>' );
+		$request->set_param( 'tax_input', array( 'pt_test_hidden' => array( 'Should Not Save' ) ) );
+
+		press_this_rest_save_post( $request );
+
+		$terms = wp_get_post_terms( $this->test_post_id, 'pt_test_hidden', array( 'fields' => 'names' ) );
+		$this->assertEmpty( $terms );
+
+		unregister_taxonomy( 'pt_test_hidden' );
+	}
+
+	/**
+	 * Test save ignores tax_input when the user lacks assign_terms capability.
+	 */
+	public function test_save_ignores_tax_input_without_capability() {
+		register_taxonomy(
+			'pt_test_locked',
+			'post',
+			array(
+				'public'       => true,
+				'show_ui'      => true,
+				'capabilities' => array(
+					'assign_terms' => 'manage_pt_test_locked',
+				),
+			)
+		);
+
+		wp_set_current_user( $this->editor_user_id );
+
+		$request = new WP_REST_Request( 'POST', '/press-this/v1/save' );
+		$request->set_param( 'post_id', $this->test_post_id );
+		$request->set_param( 'title', 'Locked Tax Test' );
+		$request->set_param( 'content', '<p>Content</p>' );
+		$request->set_param( 'tax_input', array( 'pt_test_locked' => array( 'Nope' ) ) );
+
+		press_this_rest_save_post( $request );
+
+		$terms = wp_get_post_terms( $this->test_post_id, 'pt_test_locked', array( 'fields' => 'names' ) );
+		$this->assertEmpty( $terms );
+
+		unregister_taxonomy( 'pt_test_locked' );
+	}
+
+	/**
+	 * Test save cannot use tax_input to write to category/post_tag,
+	 * bypassing the dedicated categories/tags handling.
+	 */
+	public function test_save_tax_input_cannot_override_category_or_post_tag() {
+		wp_set_current_user( $this->editor_user_id );
+
+		$request = new WP_REST_Request( 'POST', '/press-this/v1/save' );
+		$request->set_param( 'post_id', $this->test_post_id );
+		$request->set_param( 'title', 'Bypass Attempt' );
+		$request->set_param( 'content', '<p>Content</p>' );
+		$request->set_param( 'tax_input', array( 'post_tag' => array( 'sneaky-tag' ) ) );
+
+		press_this_rest_save_post( $request );
+
+		$tags = wp_get_post_tags( $this->test_post_id, array( 'fields' => 'names' ) );
+		$this->assertNotContains( 'sneaky-tag', $tags );
+	}
+
+	/**
 	 * Test save blocks external redirects.
 	 */
 	public function test_save_blocks_external_redirects() {

--- a/tests/php/test-rest-endpoints.php
+++ b/tests/php/test-rest-endpoints.php
@@ -46,6 +46,9 @@ class Test_Press_This_REST_Endpoints extends BaseTestCase {
 	public function set_up() {
 		parent::set_up();
 
+		// Ensure WordPress default roles are available.
+		populate_roles();
+
 		if ( ! class_exists( 'WP_Press_This_Plugin' ) ) {
 			require_once dirname( dirname( __DIR__ ) ) . '/class-wp-press-this-plugin.php';
 		}
@@ -78,6 +81,7 @@ class Test_Press_This_REST_Endpoints extends BaseTestCase {
 		);
 
 		wp_set_current_user( $this->editor_user_id );
+
 		$this->test_post_id = wp_insert_post(
 			array(
 				'post_author'  => $this->editor_user_id,
@@ -92,6 +96,20 @@ class Test_Press_This_REST_Endpoints extends BaseTestCase {
 	 * Tear down after each test.
 	 */
 	public function tear_down() {
+		// Clean up any test-registered taxonomies, as a backstop in case a
+		// test failed before reaching its own unregister_taxonomy() call.
+		foreach ( array(
+			'pt_test_genre',
+			'pt_test_rating',
+			'pt_test_page_only',
+			'pt_test_hidden',
+			'pt_test_locked',
+		) as $test_tax ) {
+			if ( taxonomy_exists( $test_tax ) ) {
+				unregister_taxonomy( $test_tax );
+			}
+		}
+
 		parent::tear_down();
 		remove_all_filters( 'press_this_enable_url_proxy' );
 		remove_all_filters( 'press_this_save_post' );
@@ -402,6 +420,168 @@ class Test_Press_This_REST_Endpoints extends BaseTestCase {
 		$this->assertContains( $term_id, $terms );
 
 		unregister_taxonomy( 'pt_test_genre' );
+	}
+
+	/**
+	 * Test save clears a custom taxonomy's terms when tax_input sends an
+	 * empty array for it (deselect-all flow).
+	 */
+	public function test_save_clears_custom_taxonomy_with_empty_tax_input() {
+		register_taxonomy(
+			'pt_test_genre',
+			'post',
+			array(
+				'public'       => true,
+				'show_ui'      => true,
+				'hierarchical' => true,
+				'labels'       => array( 'name' => 'Genres' ),
+			)
+		);
+
+		$term    = wp_insert_term( 'Fiction', 'pt_test_genre' );
+		$term_id = is_wp_error( $term ) ? (int) $term->get_error_data() : (int) $term['term_id'];
+		wp_set_object_terms( $this->test_post_id, array( $term_id ), 'pt_test_genre' );
+
+		wp_set_current_user( $this->editor_user_id );
+
+		$request = new WP_REST_Request( 'POST', '/press-this/v1/save' );
+		$request->set_param( 'post_id', $this->test_post_id );
+		$request->set_param( 'title', 'Genre Clear Test' );
+		$request->set_param( 'content', '<p>Content</p>' );
+		$request->set_param( 'tax_input', array( 'pt_test_genre' => array() ) );
+
+		$response = press_this_rest_save_post( $request );
+
+		$this->assertFalse( is_wp_error( $response ) );
+		$this->assertSame(
+			array(),
+			wp_get_object_terms( $this->test_post_id, 'pt_test_genre', array( 'fields' => 'ids' ) )
+		);
+
+		unregister_taxonomy( 'pt_test_genre' );
+	}
+
+	/**
+	 * Test save leaves a custom taxonomy untouched when its key is absent
+	 * from tax_input.
+	 */
+	public function test_save_leaves_custom_taxonomy_absent_from_tax_input() {
+		register_taxonomy(
+			'pt_test_genre',
+			'post',
+			array(
+				'public'       => true,
+				'show_ui'      => true,
+				'hierarchical' => true,
+				'labels'       => array( 'name' => 'Genres' ),
+			)
+		);
+
+		$term    = wp_insert_term( 'Fiction', 'pt_test_genre' );
+		$term_id = is_wp_error( $term ) ? (int) $term->get_error_data() : (int) $term['term_id'];
+		wp_set_object_terms( $this->test_post_id, array( $term_id ), 'pt_test_genre' );
+
+		wp_set_current_user( $this->editor_user_id );
+
+		$request = new WP_REST_Request( 'POST', '/press-this/v1/save' );
+		$request->set_param( 'post_id', $this->test_post_id );
+		$request->set_param( 'title', 'Genre Absent Test' );
+		$request->set_param( 'content', '<p>Content</p>' );
+		$request->set_param( 'tax_input', array() );
+
+		$response = press_this_rest_save_post( $request );
+
+		$this->assertFalse( is_wp_error( $response ) );
+		$this->assertContains(
+			$term_id,
+			wp_get_object_terms( $this->test_post_id, 'pt_test_genre', array( 'fields' => 'ids' ) )
+		);
+
+		unregister_taxonomy( 'pt_test_genre' );
+	}
+
+	/**
+	 * Test save clears tags when the tags param is an empty array
+	 * (deselect-all flow).
+	 */
+	public function test_save_clears_tags_with_empty_array() {
+		wp_set_object_terms( $this->test_post_id, array( 'stale-tag' ), 'post_tag' );
+		wp_set_current_user( $this->editor_user_id );
+
+		$request = new WP_REST_Request( 'POST', '/press-this/v1/save' );
+		$request->set_param( 'post_id', $this->test_post_id );
+		$request->set_param( 'title', 'Tag Clear Test' );
+		$request->set_param( 'content', '<p>Content</p>' );
+		$request->set_param( 'tags', array() );
+
+		$response = press_this_rest_save_post( $request );
+
+		$this->assertFalse( is_wp_error( $response ) );
+		$this->assertSame(
+			array(),
+			wp_get_object_terms( $this->test_post_id, 'post_tag', array( 'fields' => 'ids' ) )
+		);
+	}
+
+	/**
+	 * Test save clears categories when the categories param is an empty
+	 * array (deselect-all flow).
+	 */
+	public function test_save_clears_categories_with_empty_array() {
+		$term        = wp_insert_term( 'Stale Category', 'category' );
+		$category_id = is_wp_error( $term ) ? (int) $term->get_error_data()['term_id'] : (int) $term['term_id'];
+		wp_set_object_terms( $this->test_post_id, array( $category_id ), 'category' );
+		wp_set_current_user( $this->editor_user_id );
+
+		$request = new WP_REST_Request( 'POST', '/press-this/v1/save' );
+		$request->set_param( 'post_id', $this->test_post_id );
+		$request->set_param( 'title', 'Category Clear Test' );
+		$request->set_param( 'content', '<p>Content</p>' );
+		$request->set_param( 'categories', array() );
+
+		$response = press_this_rest_save_post( $request );
+
+		$this->assertFalse( is_wp_error( $response ) );
+		$this->assertSame(
+			array(),
+			wp_get_object_terms( $this->test_post_id, 'category', array( 'fields' => 'ids' ) )
+		);
+	}
+
+	/**
+	 * Test save leaves existing categories and tags alone when the params are
+	 * absent from the request. The route registers no default for them, so an
+	 * absent param never enters the "clear" branch — unlike an explicit
+	 * empty array, which does clear.
+	 */
+	public function test_save_leaves_categories_and_tags_absent_from_request() {
+		$cat_term    = wp_insert_term( 'Kept Category', 'category' );
+		$category_id = is_wp_error( $cat_term ) ? (int) $cat_term->get_error_data() : (int) $cat_term['term_id'];
+		wp_set_object_terms( $this->test_post_id, array( $category_id ), 'category' );
+		// Non-hierarchical taxonomies take term names, not IDs.
+		// Non-hierarchical taxonomies take term names, not IDs.
+		wp_set_post_tags( $this->test_post_id, array( 'Kept Tag' ) );
+		$kept_tags = wp_get_post_tags( $this->test_post_id, array( 'fields' => 'ids' ) );
+
+		wp_set_current_user( $this->editor_user_id );
+
+		$request = new WP_REST_Request( 'POST', '/press-this/v1/save' );
+		$request->set_param( 'post_id', $this->test_post_id );
+		$request->set_param( 'title', 'Params Absent Test' );
+		$request->set_param( 'content', '<p>Content</p>' );
+		// No categories or tags params set.
+
+		$response = press_this_rest_save_post( $request );
+
+		$this->assertFalse( is_wp_error( $response ) );
+		$this->assertContains(
+			$category_id,
+			wp_get_object_terms( $this->test_post_id, 'category', array( 'fields' => 'ids' ) )
+		);
+		$this->assertSame(
+			$kept_tags,
+			wp_get_post_tags( $this->test_post_id, array( 'fields' => 'ids' ) )
+		);
 	}
 
 	/**

--- a/tests/php/test-sanitization-error-handling.php
+++ b/tests/php/test-sanitization-error-handling.php
@@ -39,6 +39,9 @@ class Test_Sanitization_Error_Handling extends BaseTestCase {
 	public function set_up() {
 		parent::set_up();
 
+		// Ensure WordPress default roles are available.
+		populate_roles();
+
 		// Load the plugin class.
 		require_once dirname( dirname( __DIR__ ) ) . '/press-this-plugin.php';
 		require_once dirname( dirname( __DIR__ ) ) . '/class-wp-press-this-plugin.php';


### PR DESCRIPTION
## Summary
Custom taxonomies registered for the post type now show up in the Press This panel, alongside Categories and Tags. Previously only Category and Tags were ever shown, even if a site had other taxonomies registered.
Fixes #9

## Changes
### class-wp-press-this-plugin.php
**Before:**
```php
$categories_tax  = is_object_in_taxonomy( $post_type, 'category' ) ? get_taxonomy( 'category' ) : false;
$tag_tax         = is_object_in_taxonomy( $post_type, 'post_tag' ) ? get_taxonomy( 'post_tag' ) : false;
// ... only category/post_tag data ever built for the panel
```
**After:**
```php
$custom_taxonomies_data = $this->get_custom_taxonomies_data( $post_type );
// new method enumerates get_object_taxonomies(), excludes category/post_tag,
// filters to show_ui + assign_terms capability, bootstraps terms for hierarchical taxonomies
```
**Why:** Category and Tags keep their own dedicated panels, but every other registered taxonomy is now enumerated and sent to the editor, gated the same way Category/Tags already were (registration + capability).

### press-this-plugin.php
**Before:**
```php
// REST /save only ever accepted 'categories' and 'tags' params
```
**After:**
```php
'tax_input' => array( 'type' => 'object', 'default' => array() ),
// save handler validates each taxonomy is registered for the post type, has show_ui,
// and the user can assign_terms, before merging into $post_data['tax_input']
```
**Why:** Needed a generic way to save terms for an arbitrary taxonomy, with the same gating applied on save as on read, so a taxonomy hidden from the panel can't be written to by crafting a request by hand.

### src/components/TaxonomyPanel.js (new)
New component that renders one panel per custom taxonomy: a checkbox tree for hierarchical taxonomies (same interaction as the existing Category panel), or a token field for flat ones (same interaction as Tags).

### src/components/PressThisEditor.js, src/App.js
Wired the new `taxonomies` data through, added `taxonomyTerms` state per taxonomy, included it in the save payload.

## Testing
**Test 1: Hierarchical custom taxonomy**
1. Register a hierarchical taxonomy for `post` (e.g. `genre`) with some terms.
2. Open Press This.
3. Select a term in the new Genre panel and save as draft.
Result: post saved with the selected term.

**Test 2: Flat custom taxonomy**
1. Register a flat taxonomy for `post` (e.g. `rating`).
2. Open Press This, type a new term into the Rating panel, save.
Result: term is created and assigned to the post.

**Test 3: Gating**
1. Register a taxonomy with `show_ui => false`, or as a user without `assign_terms` capability for a taxonomy.
Result: panel doesn't show, and a hand-crafted REST request with that taxonomy in `tax_input` is silently ignored (no error, term not saved).

**Test 4: Category/Tags unaffected**
1. Use Press This as before with no custom taxonomies registered.
Result: Category and Tags panels behave exactly as before.

Ran the full PHPUnit and Jest suites plus PHPCS/ESLint, all green.