### PR TITLE
enhancement(header): link site name to wp-admin

### DIFF
--- a/class-wp-press-this-plugin.php
+++ b/class-wp-press-this-plugin.php
@@ -1559,6 +1559,18 @@ class WP_Press_This_Plugin {
 			}
 		}
 
+		/**
+		 * Filters the URL used by the site name link in the Press This header.
+		 *
+		 * Defaults to the admin dashboard so users have an easy way back
+		 * to wp-admin. The "View Site" menu item keeps using the front-end URL.
+		 *
+		 * @since 2.1.1
+		 *
+		 * @param string $admin_url URL for the header site name link. Default admin URL.
+		 */
+		$site_link_url = apply_filters( 'press_this_site_link_url', admin_url() );
+
 		// Comprehensive data object for React app.
 		$press_this_data = array(
 			// Post data.
@@ -1579,6 +1591,7 @@ class WP_Press_This_Plugin {
 			// Decode HTML entities for proper display (e.g., &#8211; to –).
 			'siteName'            => html_entity_decode( get_bloginfo( 'name', 'display' ), ENT_QUOTES | ENT_HTML5, 'UTF-8' ),
 			'siteUrl'             => home_url( '/' ),
+			'adminUrl'            => $site_link_url,
 			'ajaxUrl'             => admin_url( 'admin-ajax.php' ),
 			'restUrl'             => rest_url( 'press-this/v1/' ),
 			'restNonce'           => wp_create_nonce( 'wp_rest' ),
@@ -1752,6 +1765,10 @@ class WP_Press_This_Plugin {
 </html>
 		<?php
 		// phpcs:enable WordPress.Security.NonceVerification.Missing, WordPress.Security.NonceVerification.Recommended
+		// Return during unit tests so output can be captured; die in production.
+		if ( defined( 'PRESS_THIS_PHPUNIT' ) && PRESS_THIS_PHPUNIT ) {
+			return;
+		}
 		die();
 	}
 

--- a/src/App.js
+++ b/src/App.js
@@ -398,6 +398,7 @@ export default function App() {
 			<Header
 				siteName={ data.siteName }
 				siteUrl={ data.siteUrl }
+				adminUrl={ data.adminUrl }
 				sourceUrl={ data.sourceUrl }
 				isLegacyBookmarklet={ data.isLegacyBookmarklet }
 				hasBookmarkletContent={ !! data.content }

--- a/src/components/Header.js
+++ b/src/components/Header.js
@@ -201,6 +201,7 @@ function isFutureDate( dateString, tz ) {
  * @param {Object}   props                       Component props.
  * @param {string}   props.siteName              Site name.
  * @param {string}   props.siteUrl               Site URL.
+ * @param {string}   props.adminUrl              Admin URL used by the site name link.
  * @param {string}   props.sourceUrl             Source URL being clipped.
  * @param {boolean}  props.isLegacyBookmarklet   Whether this is a legacy bookmarklet.
  * @param {boolean}  props.hasBookmarkletContent Whether content was already provided by bookmarklet.
@@ -232,6 +233,7 @@ export {
 export default function Header( {
 	siteName,
 	siteUrl,
+	adminUrl,
 	sourceUrl,
 	isLegacyBookmarklet,
 	hasBookmarkletContent = false,
@@ -511,7 +513,7 @@ export default function Header( {
 			<div className="press-this-header__bar">
 				<div className="press-this-header__site">
 					<a
-						href={ siteUrl }
+						href={ adminUrl || siteUrl }
 						target="_blank"
 						rel="noopener noreferrer"
 						className="press-this-header__site-link"

--- a/tests/components/header-site-link.test.js
+++ b/tests/components/header-site-link.test.js
@@ -1,0 +1,41 @@
+/**
+ * Header Site Link Tests
+ *
+ * Verifies the site name link in the header points to wp-admin
+ * (adminUrl) with a front-end fallback, while the View Site menu
+ * item keeps using the front-end URL. See GitHub issue #4.
+ *
+ * @package press-this
+ */
+
+const fs = require( 'fs' );
+const path = require( 'path' );
+
+describe( 'Header Site Link', () => {
+	let headerContent;
+	let appContent;
+
+	beforeAll( () => {
+		const headerPath = path.resolve( __dirname, '../../src/components/Header.js' );
+		headerContent = fs.readFileSync( headerPath, 'utf8' );
+
+		const appPath = path.resolve( __dirname, '../../src/App.js' );
+		appContent = fs.readFileSync( appPath, 'utf8' );
+	} );
+
+	test( 'Header accepts adminUrl prop', () => {
+		expect( headerContent ).toContain( 'adminUrl' );
+	} );
+
+	test( 'site name link uses adminUrl with siteUrl fallback', () => {
+		expect( headerContent ).toContain( 'href={ adminUrl || siteUrl }' );
+	} );
+
+	test( 'View Site menu item still uses siteUrl', () => {
+		expect( headerContent ).toContain( 'href={ siteUrl }' );
+	} );
+
+	test( 'App passes adminUrl from pressThisData to Header', () => {
+		expect( appContent ).toContain( 'adminUrl={ data.adminUrl }' );
+	} );
+} );

--- a/tests/php/bootstrap.php
+++ b/tests/php/bootstrap.php
@@ -21,6 +21,11 @@ if ( ! defined( 'DOING_AJAX' ) ) {
 	define( 'DOING_AJAX', true );
 }
 
+// Signal unit tests so html() returns instead of die() and output can be captured.
+if ( ! defined( 'PRESS_THIS_PHPUNIT' ) ) {
+	define( 'PRESS_THIS_PHPUNIT', true );
+}
+
 // Initialize WorDBless with SQLite database support.
 // This enables full database operations including taxonomies and categories.
 // Note: First run shows "no such table: wp_options" error during initialization,

--- a/tests/php/test-integration.php
+++ b/tests/php/test-integration.php
@@ -115,8 +115,9 @@ class Test_Press_This_Integration extends BaseTestCase {
 			);
 		}
 
-		// Anchor to </script> to avoid early termination on }; inside JSON strings.
-		preg_match( '/window\.pressThisData\s*=\s*({.+?})\s*;\s*<\/script>/s', $html, $matches );
+		// wp_json_encode emits a single line; match that line only (no /s)
+		// so later script tags cannot bleed into the capture.
+		preg_match( '/window\.pressThisData\s*=\s*(\{.*\})\s*;/', $html, $matches );
 
 		$this->assertNotEmpty( $matches[1], 'pressThisData JSON not found in html() output.' );
 
@@ -384,5 +385,44 @@ class Test_Press_This_Integration extends BaseTestCase {
 		$this->assertFalse( $data['windowNameMode'], 'windowNameMode should be false when only pm=1.' );
 
 		unset( $_GET['pm'] );
+	}
+
+	/**
+	 * Test: adminUrl defaults to the admin dashboard URL.
+	 *
+	 * The header site name link uses adminUrl so users have an easy
+	 * way back to wp-admin. See GitHub issue #4.
+	 */
+	public function test_admin_url_defaults_to_admin_dashboard() {
+		$data = $this->get_press_this_data_from_html();
+
+		$this->assertArrayHasKey( 'adminUrl', $data );
+		$this->assertSame( admin_url(), $data['adminUrl'] );
+	}
+
+	/**
+	 * Test: press_this_site_link_url filter changes adminUrl.
+	 */
+	public function test_site_link_url_filter_works() {
+		$site_link_filter = function () {
+			return 'https://example.com/custom-dashboard/';
+		};
+		add_filter( 'press_this_site_link_url', $site_link_filter );
+
+		try {
+			$data = $this->get_press_this_data_from_html();
+			$this->assertSame( 'https://example.com/custom-dashboard/', $data['adminUrl'] );
+		} finally {
+			remove_filter( 'press_this_site_link_url', $site_link_filter );
+		}
+	}
+
+	/**
+	 * Test: siteUrl still points to the front-end for the View Site menu item.
+	 */
+	public function test_site_url_still_points_to_front_end() {
+		$data = $this->get_press_this_data_from_html();
+
+		$this->assertSame( home_url( '/' ), $data['siteUrl'] );
 	}
 }

--- a/tests/php/test-press-this-plugin.php
+++ b/tests/php/test-press-this-plugin.php
@@ -304,7 +304,9 @@ class Test_WP_Press_This_Plugin extends BaseTestCase {
 			$_SERVER['REQUEST_METHOD'] = $previous_method;
 		}
 
-		preg_match( '/window\.pressThisData\s*=\s*({.+?});/s', $html, $matches );
+		// wp_json_encode emits a single line; match that line only (no /s)
+		// so later script tags cannot bleed into the capture.
+		preg_match( '/window\.pressThisData\s*=\s*(\{.*\})\s*;/', $html, $matches );
 
 		// If pressThisData was not found and an exception was caught, surface it
 		// so test failures point to the actual error, not a generic message.


### PR DESCRIPTION
## Summary
The site name in the Press This header linked to the site front-end (`home_url()`) instead of wp-admin, leaving no quick way back to the dashboard. The header site name now opens `wp-admin`, and the link is filterable.

Resolves #4

## Changes
### class-wp-press-this-plugin.php
**Before:**
```php
'siteUrl' => home_url( '/' ),
```

**After:**
```php
$site_link_url = apply_filters( 'press_this_site_link_url', admin_url() );

$press_this_data = array(
	// ...
	'siteUrl' => home_url( '/' ),
	'adminUrl' => $site_link_url,
```

**Why:** Adds a new `adminUrl` key defaulting to the dashboard, with a `press_this_site_link_url` filter so the link target can be changed without overriding the data array. The existing `siteUrl` key is untouched, so the standalone-mode "View Site" menu item still points to the front-end.

### src/App.js + src/components/Header.js
**Before:**
```jsx
<a href={ siteUrl } target="_blank" rel="noopener noreferrer" className="press-this-header__site-link">
```

**After:**
```jsx
<a href={ adminUrl || siteUrl } target="_blank" rel="noopener noreferrer" className="press-this-header__site-link">
```

**Why:** The site name link uses `adminUrl` with a `siteUrl` fallback for backward compatibility. App passes `adminUrl={ data.adminUrl }` through to the Header.

Also guarding `html()` so it returns instead of `die()` when `PRESS_THIS_PHPUNIT` is defined, which lets the existing test helper capture `window.pressThisData`. This fixed a broken JSON-extraction regex in two test helpers that never ran to completion before.

## Testing
**Test 1: Site name opens wp-admin**
1. Open Press This (Tools → Press This, or bookmarklet)
2. Click the WordPress icon / site name in the header
3. Confirm a new tab opens `…/wp-admin/` (dashboard)

Result: link points to wp-admin, not the front-end

**Test 2: View Site still opens front-end**
1. Open Press This in standalone mode
2. Open the header overflow menu (⋮)
3. Click View Site (only shown in standalone mode)

Result: opens the public front-end (`home_url`)

**Test 3: Filter override (optional)**
1. Add to a theme `functions.php` or mu-plugin:
   ```php
   add_filter( 'press_this_site_link_url', function () {
       return home_url( '/' );
   } );
   ```
2. Reload Press This and click the site name

Result: link follows the filtered URL

**Tests already passing**
- `composer test:php` — new adminUrl tests pass (1 pre-existing unrelated failure in `test_generic_error_messages_hide_details`, a DNS/environment artifact)
- `npm run test:unit` — 368 pass, including new Header site-link tests
- `npm run build` — assets rebuilt