### PR TITLE
Update tested up to WordPress 7.1

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -3,7 +3,7 @@ Contributors: kraftbj, wordpressdotorg
 Donate link: http://wordpressfoundation.org/donate/
 Tags: post, quick-post, photo-post, bookmarklet, gutenberg
 Requires at least: 6.9
-Tested up to: 7.0
+Tested up to: 7.1
 Stable tag: 2.1.0
 Requires PHP: 7.4
 License: GPLv2 or later


### PR DESCRIPTION
Updates the `Tested up to` header in `readme.txt` to WordPress 7.1.

Readme header only — no functional changes.

## Testing instructions

* Verify `readme.txt` shows `Tested up to: 7.1`.
