### PR TITLE
Preserve pasted content instead of dropping non-curated blocks

### DIFF
--- a/class-wp-press-this-plugin.php
+++ b/class-wp-press-this-plugin.php
@@ -1254,11 +1254,17 @@ class WP_Press_This_Plugin {
 	}
 
 	/**
-	 * Get the allowed blocks for the block editor.
+	 * Get the blocks featured in the editor's inserter.
+	 *
+	 * These blocks are the curated set shown in the "Add block" inserter to keep
+	 * the quick-post experience focused. All other block types remain registered
+	 * and insertable — they are only hidden from the inserter UI — so pasted or
+	 * scraped content of any type (tables, columns, etc.) is preserved rather
+	 * than dropped.
 	 *
 	 * @since 2.0.1
 	 *
-	 * @return array Array of allowed block type names.
+	 * @return array Array of block type names shown in the inserter.
 	 */
 	public function get_allowed_blocks() {
 		$default_blocks = array(
@@ -1273,11 +1279,14 @@ class WP_Press_This_Plugin {
 		);
 
 		/**
-		 * Filters the allowed blocks in Press This.
+		 * Filters the blocks featured in the Press This inserter.
+		 *
+		 * This controls which blocks appear in the inserter UI only. It does not
+		 * restrict which blocks can be pasted or inserted programmatically.
 		 *
 		 * @since 2.0.1
 		 *
-		 * @param string[] $allowed_blocks Array of allowed block type names.
+		 * @param string[] $allowed_blocks Array of block type names shown in the inserter.
 		 */
 		return apply_filters( 'press_this_allowed_blocks', $default_blocks );
 	}

--- a/includes/class-press-this-assets.php
+++ b/includes/class-press-this-assets.php
@@ -228,6 +228,7 @@ class Press_This_Assets {
 			'wp-dom-ready',
 			'wp-element',
 			'wp-format-library',
+			'wp-hooks',
 			'wp-html-entities',
 			'wp-i18n',
 			'wp-keyboard-shortcuts',

--- a/package-lock.json
+++ b/package-lock.json
@@ -22,6 +22,7 @@
         "@wordpress/editor": "^14.37.0",
         "@wordpress/element": "^6.37.0",
         "@wordpress/format-library": "^5.37.0",
+        "@wordpress/hooks": "^4.54.0",
         "@wordpress/html-entities": "^4.40.0",
         "@wordpress/i18n": "^6.10.0",
         "@wordpress/icons": "^11.4.0",
@@ -10382,9 +10383,9 @@
       }
     },
     "node_modules/@wordpress/hooks": {
-      "version": "4.41.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/hooks/-/hooks-4.41.0.tgz",
-      "integrity": "sha512-WDbLcLA3DOcjDGNLcxHZTPyhltWd/75G2hxFphe/hzcJUNmgysDTSSXO/bBrIWf6rwWD6TS3ejCaGC9J6DwYiw==",
+      "version": "4.54.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/hooks/-/hooks-4.54.0.tgz",
+      "integrity": "sha512-9eMe48ixxAd+ILuXe3n+zOc1XlphfPppf0drTuJEjJy0xGXV7eUw459KEvk4KCrznb9pKemHjj4mGjogV5f1CQ==",
       "license": "GPL-2.0-or-later",
       "engines": {
         "node": ">=18.12.0",

--- a/package.json
+++ b/package.json
@@ -54,6 +54,7 @@
     "@wordpress/editor": "^14.37.0",
     "@wordpress/element": "^6.37.0",
     "@wordpress/format-library": "^5.37.0",
+    "@wordpress/hooks": "^4.54.0",
     "@wordpress/html-entities": "^4.40.0",
     "@wordpress/i18n": "^6.10.0",
     "@wordpress/icons": "^11.4.0",

--- a/src/components/PressThisEditor.js
+++ b/src/components/PressThisEditor.js
@@ -43,6 +43,7 @@ import {
 } from '@wordpress/components';
 import { __, sprintf } from '@wordpress/i18n';
 import { registerCoreBlocks } from '@wordpress/block-library';
+import { addFilter } from '@wordpress/hooks';
 
 /**
  * Internal dependencies
@@ -83,11 +84,49 @@ function SidebarBlockInspector() {
 
 // Ensure core blocks are registered.
 let blocksRegistered = false;
-function ensureBlocksRegistered() {
-	if ( ! blocksRegistered ) {
-		registerCoreBlocks();
-		blocksRegistered = true;
+
+/**
+ * Register core blocks, curating which ones appear in the inserter.
+ *
+ * All core blocks are registered so that pasted or scraped content of any
+ * type is preserved. Blocks outside the curated list are hidden from the
+ * inserter UI via `supports.inserter: false`, which keeps the quick-post
+ * experience focused without blocking insertion. Crucially, `inserter: false`
+ * does not affect `canInsertBlockType`, so pasting content that produces
+ * non-curated blocks (tables, columns, etc.) still works — unlike an
+ * `allowedBlockTypes` allowlist, which makes the block editor silently drop
+ * the entire paste when any block is disallowed.
+ *
+ * @param {string[]} inserterBlocks Block names to keep visible in the inserter.
+ */
+function ensureBlocksRegistered( inserterBlocks = [] ) {
+	if ( blocksRegistered ) {
+		return;
 	}
+
+	// Hide non-curated blocks from the inserter. Added before registration so
+	// the support flag is baked into each block type as it registers.
+	if ( Array.isArray( inserterBlocks ) && inserterBlocks.length ) {
+		addFilter(
+			'blocks.registerBlockType',
+			'press-this/curate-inserter',
+			( blockSettings, name ) => {
+				if ( inserterBlocks.includes( name ) ) {
+					return blockSettings;
+				}
+				return {
+					...blockSettings,
+					supports: {
+						...( blockSettings.supports || {} ),
+						inserter: false,
+					},
+				};
+			}
+		);
+	}
+
+	registerCoreBlocks();
+	blocksRegistered = true;
 }
 
 /**
@@ -310,10 +349,10 @@ export default function PressThisEditor( {
 	categoryNonce = '',
 	ajaxUrl = '',
 } ) {
-	// Register blocks on mount.
+	// Register blocks on mount, curating the inserter to the configured list.
 	useEffect( () => {
-		ensureBlocksRegistered();
-	}, [] );
+		ensureBlocksRegistered( settings.allowedBlocks );
+	}, [] ); // eslint-disable-line react-hooks/exhaustive-deps
 
 	// State for blocks and post data.
 	const [ blocks, setBlocks ] = useState( [] );
@@ -731,7 +770,15 @@ export default function PressThisEditor( {
 	// Editor settings.
 	const editorSettings = useMemo(
 		() => ( {
-			allowedBlockTypes: settings.allowedBlocks,
+			/*
+			 * Allow every block type to be inserted. The inserter is curated
+			 * separately via supports.inserter (see ensureBlocksRegistered), so
+			 * this does not clutter the quick-post UI. Using `true` here — rather
+			 * than an allowlist — is essential: an allowedBlockTypes allowlist
+			 * makes the block editor silently discard an entire paste when any
+			 * pasted block is disallowed (e.g. a table in a copied article).
+			 */
+			allowedBlockTypes: true,
 			hasFixedToolbar: true,
 			bodyPlaceholder: __(
 				'Start writing or press / to choose a block',

--- a/tests/e2e/paste-preservation.spec.js
+++ b/tests/e2e/paste-preservation.spec.js
@@ -1,0 +1,136 @@
+/**
+ * Paste Preservation E2E Tests
+ *
+ * Regression coverage for the "cannot paste certain content" bug: when the
+ * editor restricted insertion to an allowedBlockTypes allowlist, Gutenberg's
+ * replaceBlocks() silently discarded the ENTIRE paste if any pasted block was
+ * outside the list (a table, columns, etc.). The user saw nothing happen.
+ *
+ * The editor now allows every block type to be inserted (the inserter is
+ * curated separately via supports.inserter), so pasted content of any type is
+ * preserved. These tests paste HTML directly through a real ClipboardEvent —
+ * the same code path a browser paste uses.
+ */
+/* global DataTransfer, ClipboardEvent */
+const { test, expect } = require( './utils/auth' );
+
+const editorContent = '.press-this-editor__content';
+
+/**
+ * Load the editor and place the caret in a fresh empty paragraph.
+ *
+ * @param {import('@playwright/test').Page} page Playwright page.
+ */
+async function loadEditorWithEmptyParagraph( page ) {
+	await page.goto( '/wp-admin/press-this.php' );
+	await page.locator( editorContent ).waitFor( { timeout: 10000 } );
+
+	// Create the default paragraph via the block appender and focus it.
+	await page
+		.locator( `${ editorContent } [aria-label="Add default block"]` )
+		.first()
+		.click();
+	const editable = page
+		.locator( `${ editorContent } [contenteditable="true"]` )
+		.first();
+	await editable.waitFor( { timeout: 10000 } );
+	await editable.click();
+}
+
+/**
+ * Dispatch a real paste event carrying HTML into the focused editable region.
+ *
+ * @param {import('@playwright/test').Page} page  Playwright page.
+ * @param {string}                          html  The text/html clipboard payload.
+ * @param {string}                          plain The text/plain clipboard payload.
+ */
+async function pasteHtml( page, html, plain ) {
+	await page.evaluate(
+		( { html: h, plain: p } ) => {
+			const editable = document.querySelector(
+				'.press-this-editor__content [contenteditable="true"]'
+			);
+			editable.focus();
+			const dt = new DataTransfer();
+			dt.setData( 'text/html', h );
+			dt.setData( 'text/plain', p );
+			editable.dispatchEvent(
+				new ClipboardEvent( 'paste', {
+					bubbles: true,
+					cancelable: true,
+					clipboardData: dt,
+				} )
+			);
+		},
+		{ html, plain }
+	);
+}
+
+test.describe( 'Paste Preservation', () => {
+	test( 'pasting a table inserts a table block', async ( {
+		loggedInPage: page,
+	} ) => {
+		await loadEditorWithEmptyParagraph( page );
+
+		await pasteHtml(
+			page,
+			'<table><thead><tr><th>Function</th><th>Component</th></tr></thead><tbody><tr><td>Documents</td><td>Collabora</td></tr></tbody></table>',
+			'Function\tComponent\nDocuments\tCollabora'
+		);
+
+		await expect(
+			page.locator( `${ editorContent } [data-type="core/table"]` )
+		).toBeVisible();
+		await expect( page.locator( editorContent ) ).toContainText(
+			'Collabora'
+		);
+	} );
+
+	test( 'mixed allowed and non-allowed content all lands', async ( {
+		loggedInPage: page,
+	} ) => {
+		await loadEditorWithEmptyParagraph( page );
+
+		// A table sits between two paragraphs. Under the old allowlist the whole
+		// paste was dropped — including the two valid paragraphs.
+		await pasteHtml(
+			page,
+			'<p>Paragraph before the table.</p><table><tbody><tr><td>A</td><td>B</td></tr></tbody></table><p>Paragraph after the table.</p>',
+			'Paragraph before the table.\nA\tB\nParagraph after the table.'
+		);
+
+		await expect(
+			page.locator( `${ editorContent } [data-type="core/table"]` )
+		).toBeVisible();
+		await expect( page.locator( editorContent ) ).toContainText(
+			'Paragraph before the table.'
+		);
+		await expect( page.locator( editorContent ) ).toContainText(
+			'Paragraph after the table.'
+		);
+	} );
+
+	test( 'inserter stays curated to the focused block set', async ( {
+		loggedInPage: page,
+	} ) => {
+		await page.goto( '/wp-admin/press-this.php' );
+		await page.locator( editorContent ).waitFor( { timeout: 10000 } );
+
+		const { inserterTypes, canInsertTable } = await page.evaluate( () => {
+			const store = window.wp.data.select( 'core/block-editor' );
+			const types = [
+				...new Set( store.getInserterItems().map( ( i ) => i.name ) ),
+			];
+			return {
+				inserterTypes: types,
+				canInsertTable: store.canInsertBlockType( 'core/table' ),
+			};
+		} );
+
+		// Non-curated blocks are hidden from the inserter...
+		expect( inserterTypes ).not.toContain( 'core/table' );
+		expect( inserterTypes ).toContain( 'core/paragraph' );
+		// ...but remain insertable, which is what keeps paste working.
+		expect( canInsertTable ).toBe( true );
+	} );
+} );


### PR DESCRIPTION
## Summary

Pasting certain content into Press This inserted **nothing** — no content, no error. This fixes that while keeping the editor's intentionally focused block set.

See #170

## Root cause

The editor restricted insertion to an `allowedBlockTypes` allowlist (paragraph, heading, image, quote, list, embed). Gutenberg's `replaceBlocks()` — the action the paste path calls — validates the whole set and bails entirely if **any** block is not allowed:

```js
// @wordpress/block-editor store/actions
for ( const block of blocks ) {
  if ( ! canInsertBlockType( block.name, rootClientId ) ) {
    return; // drops the ENTIRE paste, silently
  }
}
```

So a copied article containing a table, columns, or a figure anywhere in the selection pasted as nothing — the valid paragraphs and headings were discarded along with the disallowed block. Scraped/bookmarklet content was unaffected because that path writes blocks straight into the provider value and never goes through `replaceBlocks`.

## Change

- Set `allowedBlockTypes: true` so paste preserves content of any type.
- Curate the inserter separately: a `blocks.registerBlockType` filter sets `supports.inserter: false` on non-featured blocks. `supports.inserter` hides a block from the "Add block" UI but does **not** affect `canInsertBlockType`, so the quick-post inserter stays focused while paste keeps everything.
- The `press_this_allowed_blocks` filter / `get_allowed_blocks()` now curate the inserter rather than gate paste; docblocks updated to say so.
- Added `@wordpress/hooks` as a dependency (used by the new filter) and to the asset fallback dependency list.

## Testing

Verified in a live WordPress (Playground) with the real plugin and real paste events:

| Case | Before | After |
|---|---|---|
| Paste a `<table>` | nothing | table block inserts |
| Paste `<p>` + `<table>` + `<p>` | nothing (paragraphs dropped too) | all three land |
| Paste a full real web article | nothing | 45 blocks (paragraphs, headings, table, image, list) |
| Inserter contents | curated set | still curated (no table/columns/etc.); `canInsertBlockType('core/table') === true` |

- `npm run test:js` → 364/364 pass
- `npm run lint` → clean
- Added `tests/e2e/paste-preservation.spec.js` covering the cases above.

Draft: opening for review before requesting review.
